### PR TITLE
Add account registration logic with repository and controller

### DIFF
--- a/ECommerceBatteryShop.DataAccess/Abstract/IAccountRepository.cs
+++ b/ECommerceBatteryShop.DataAccess/Abstract/IAccountRepository.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+using ECommerceBatteryShop.Domain.Entities;
 
-namespace ECommerceBatteryShop.DataAccess.Abstract
+namespace ECommerceBatteryShop.DataAccess.Abstract;
+
+public interface IAccountRepository
 {
-    internal interface IAccountRepository
-    {
-    }
+    Task<User?> RegisterAsync(string email, string password, CancellationToken ct = default);
 }

--- a/ECommerceBatteryShop.DataAccess/Concrete/AccountRepository.cs
+++ b/ECommerceBatteryShop.DataAccess/Concrete/AccountRepository.cs
@@ -1,12 +1,47 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+using System.Security.Cryptography;
 using System.Text;
-using System.Threading.Tasks;
+using ECommerceBatteryShop.DataAccess.Abstract;
+using ECommerceBatteryShop.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
-namespace ECommerceBatteryShop.DataAccess.Concrete
+namespace ECommerceBatteryShop.DataAccess.Concrete;
+
+public sealed class AccountRepository : IAccountRepository
 {
-    internal class AccountRepository
+    private readonly BatteryShopContext _ctx;
+    private readonly ILogger<AccountRepository> _log;
+
+    public AccountRepository(BatteryShopContext ctx, ILogger<AccountRepository> log)
     {
+        _ctx = ctx;
+        _log = log;
+    }
+
+    public async Task<User?> RegisterAsync(string email, string password, CancellationToken ct = default)
+    {
+        if (await _ctx.Users.AnyAsync(u => u.Email == email, ct))
+        {
+            _log.LogInformation("Email already exists: {Email}", email);
+            return null;
+        }
+
+        var user = new User
+        {
+            Email = email,
+            PasswordHash = HashPassword(password),
+            CreatedAt = DateTime.UtcNow
+        };
+
+        _ctx.Users.Add(user);
+        await _ctx.SaveChangesAsync(ct);
+        return user;
+    }
+
+    private static string HashPassword(string password)
+    {
+        using var sha = SHA256.Create();
+        var bytes = sha.ComputeHash(Encoding.UTF8.GetBytes(password));
+        return Convert.ToBase64String(bytes);
     }
 }

--- a/ECommerceBatteryShop/Controllers/AccountController.cs
+++ b/ECommerceBatteryShop/Controllers/AccountController.cs
@@ -1,32 +1,64 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using ECommerceBatteryShop.DataAccess.Abstract;
+using ECommerceBatteryShop.Models;
+using Microsoft.AspNetCore.Mvc;
 
-namespace ECommerceBatteryShop.Controllers
+namespace ECommerceBatteryShop.Controllers;
+
+public class AccountController : Controller
 {
-    public class AccountController : Controller
+    private readonly IAccountRepository _accountRepository;
+
+    public AccountController(IAccountRepository accountRepository)
     {
-        public IActionResult Register()
+        _accountRepository = accountRepository;
+    }
+
+    [HttpGet]
+    public IActionResult Register()
+    {
+        return View();
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> Register(RegisterViewModel model, CancellationToken ct)
+    {
+        if (!ModelState.IsValid)
         {
-            return View();
+            return View(model);
         }
-        public IActionResult LogIn()
+
+        var user = await _accountRepository.RegisterAsync(model.Email, model.Password, ct);
+        if (user == null)
         {
-            return View();
+            ModelState.AddModelError(string.Empty, "Email already exists");
+            return View(model);
         }
-        public IActionResult ForgotPassword()
-        {
-            return View();
-        }
-        public IActionResult ResetPassword()
-        {
-            return View();
-        }
-        public IActionResult Profile()
-        {
-            return View();
-        }
-        public IActionResult VerifyAccount()
-        {
-            return View();
-        }
+
+        return RedirectToAction(nameof(LogIn));
+    }
+
+    public IActionResult LogIn()
+    {
+        return View();
+    }
+
+    public IActionResult ForgotPassword()
+    {
+        return View();
+    }
+
+    public IActionResult ResetPassword()
+    {
+        return View();
+    }
+
+    public IActionResult Profile()
+    {
+        return View();
+    }
+
+    public IActionResult VerifyAccount()
+    {
+        return View();
     }
 }

--- a/ECommerceBatteryShop/Models/RegisterViewModel.cs
+++ b/ECommerceBatteryShop/Models/RegisterViewModel.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ECommerceBatteryShop.Models;
+
+public class RegisterViewModel
+{
+    [Required, EmailAddress]
+    public string Email { get; set; } = string.Empty;
+
+    [Required, MinLength(6)]
+    public string Password { get; set; } = string.Empty;
+
+    [Required, Compare("Password")]
+    public string ConfirmPassword { get; set; } = string.Empty;
+}

--- a/ECommerceBatteryShop/Program.cs
+++ b/ECommerceBatteryShop/Program.cs
@@ -13,6 +13,7 @@ builder.Services.AddDbContext<BatteryShopContext>(opt =>
     opt.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
 
 builder.Services.AddScoped<IProductRepository, ProductRepository>();
+builder.Services.AddScoped<IAccountRepository, AccountRepository>();
 builder.Services.AddMemoryCache();
 
 // Options (with validation is better)


### PR DESCRIPTION
## Summary
- implement `RegisterViewModel` and new register action in `AccountController`
- add `IAccountRepository` and its `AccountRepository` implementation for user persistence with hashed passwords
- wire up account repository in service registration

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dbf050fc832094af390d90109dc9