### PR TITLE
Persist cart items and update navbar count via HTMX

### DIFF
--- a/ECommerceBatteryShop.DataAccess/Abstract/ICartRepository.cs
+++ b/ECommerceBatteryShop.DataAccess/Abstract/ICartRepository.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ECommerceBatteryShop.DataAccess.Abstract;
+
+public interface ICartRepository
+{
+    Task<int> AddToCartAsync(int userId, int productId, int quantity = 1, CancellationToken ct = default);
+    Task<int> GetCartItemCountAsync(int userId, CancellationToken ct = default);
+}

--- a/ECommerceBatteryShop.DataAccess/Concrete/CartRepository.cs
+++ b/ECommerceBatteryShop.DataAccess/Concrete/CartRepository.cs
@@ -1,0 +1,70 @@
+using ECommerceBatteryShop.DataAccess.Abstract;
+using ECommerceBatteryShop.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ECommerceBatteryShop.DataAccess.Concrete;
+
+public class CartRepository : ICartRepository
+{
+    private readonly BatteryShopContext _ctx;
+    private readonly ILogger<CartRepository> _log;
+
+    public CartRepository(BatteryShopContext ctx, ILogger<CartRepository> log)
+    {
+        _ctx = ctx;
+        _log = log;
+    }
+
+    public async Task<int> AddToCartAsync(int userId, int productId, int quantity = 1, CancellationToken ct = default)
+    {
+        var cart = await _ctx.Carts
+            .Include(c => c.Items)
+            .FirstOrDefaultAsync(c => c.UserId == userId, ct);
+
+        if (cart == null)
+        {
+            cart = new Cart { UserId = userId, CreatedAt = DateTime.UtcNow };
+            _ctx.Carts.Add(cart);
+        }
+
+        var product = await _ctx.Products.FindAsync(new object?[] { productId }, ct);
+        if (product == null)
+        {
+            _log.LogWarning("Product {ProductId} not found when adding to cart", productId);
+            return await GetCartItemCountAsync(userId, ct);
+        }
+
+        var item = cart.Items.FirstOrDefault(i => i.ProductId == productId);
+        if (item == null)
+        {
+            cart.Items.Add(new CartItem
+            {
+                ProductId = productId,
+                Quantity = quantity,
+                UnitPrice = product.Price
+            });
+        }
+        else
+        {
+            item.Quantity += quantity;
+        }
+
+        await _ctx.SaveChangesAsync(ct);
+        return cart.Items.Sum(i => i.Quantity);
+    }
+
+    public async Task<int> GetCartItemCountAsync(int userId, CancellationToken ct = default)
+    {
+        var cart = await _ctx.Carts
+            .AsNoTracking()
+            .Include(c => c.Items)
+            .FirstOrDefaultAsync(c => c.UserId == userId, ct);
+
+        return cart?.Items.Sum(i => i.Quantity) ?? 0;
+    }
+}

--- a/ECommerceBatteryShop/Controllers/CartController.cs
+++ b/ECommerceBatteryShop/Controllers/CartController.cs
@@ -1,12 +1,30 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using ECommerceBatteryShop.DataAccess.Abstract;
+using Microsoft.AspNetCore.Mvc;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace ECommerceBatteryShop.Controllers
 {
     public class CartController : Controller
     {
+        private readonly ICartRepository _repo;
+
+        public CartController(ICartRepository repo)
+        {
+            _repo = repo;
+        }
+
         public IActionResult Index()
         {
             return View();
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Add(int productId, int quantity = 1, CancellationToken ct = default)
+        {
+            const int userId = 1; // TODO: replace with actual authenticated user id
+            var count = await _repo.AddToCartAsync(userId, productId, quantity, ct);
+            return PartialView("_CartCount", count);
         }
     }
 }

--- a/ECommerceBatteryShop/Program.cs
+++ b/ECommerceBatteryShop/Program.cs
@@ -14,6 +14,7 @@ builder.Services.AddDbContext<BatteryShopContext>(opt =>
 
 builder.Services.AddScoped<IProductRepository, ProductRepository>();
 builder.Services.AddScoped<IAccountRepository, AccountRepository>();
+builder.Services.AddScoped<ICartRepository, CartRepository>();
 builder.Services.AddMemoryCache();
 
 // Options (with validation is better)

--- a/ECommerceBatteryShop/Views/Product/Details.cshtml
+++ b/ECommerceBatteryShop/Views/Product/Details.cshtml
@@ -63,6 +63,9 @@
 
                     <!-- CTA buttons -->
                     <button type="button"
+                            hx-post='@Url.Action("Add","Cart")'
+                            hx-vals='js:{ productId: @Model.Id, quantity: qty }'
+                            hx-swap="none"
                             @@click="addToCart(false)"
                             class="h-11 px-5 cursor-pointer rounded-xl bg-amber-300 text-slate-900 font-semibold shadow-sm hover:bg-amber-400 focus:outline-none focus:ring-1 focus:ring-amber-100">
                         Sepete Ekle

--- a/ECommerceBatteryShop/Views/Product/Index.cshtml
+++ b/ECommerceBatteryShop/Views/Product/Index.cshtml
@@ -61,6 +61,8 @@
             <div class="px-4 pb-4 pt-0">
                 <div x-data="{ added:false }">
                     <button type="button"
+                            hx-post='@Url.Action("Add","Cart", new { productId = product.Id })'
+                            hx-swap="none"
                             @@click ="if (added) return; added = true; setTimeout(()=>added=false,1600)"
                             class="relative w-full h-10 rounded-xl text-sm font-semibold shadow
                                    transition-colors duration-200 overflow-hidden cursor-pointer"

--- a/ECommerceBatteryShop/Views/Shared/_CartCount.cshtml
+++ b/ECommerceBatteryShop/Views/Shared/_CartCount.cshtml
@@ -1,0 +1,3 @@
+@model int
+<span id="cart-count-desktop" hx-swap-oob="true">@((Model > 99) ? "99+" : Model.ToString())</span>
+<span id="cart-count-mobile" hx-swap-oob="true">@((Model > 99) ? "99+" : Model.ToString())</span>

--- a/ECommerceBatteryShop/Views/Shared/_Layout.cshtml
+++ b/ECommerceBatteryShop/Views/Shared/_Layout.cshtml
@@ -41,7 +41,7 @@
                          stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
                         <path d="M6.3 5H21L19 12H7.38M20 16H8L6 3H3M9 20a1 1 0 1 1-2 0a1 1 0 0 1 2 0ZM20 20a1 1 0 1 1-2 0a1 1 0 0 1 2 0Z" />
                     </svg>
-                    <span class="absolute -top-1 -right-1 min-w-[1.1rem] h-5 px-1 rounded-full text-[10px] font-medium
+                    <span id="cart-count-mobile" class="absolute -top-1 -right-1 min-w-[1.1rem] h-5 px-1 rounded-full text-[10px] font-medium
                    bg-amber-300 text-gray-900 grid place-items-center ring-1 ring-black/10">
                         @((ViewBag.CartCount is int c1 && c1 > 99) ? "99+" : (ViewBag.CartCount ?? 0).ToString())
                     </span>
@@ -133,7 +133,7 @@
                                 <path d="M6.3 5H21L19 12H7.38M20 16H8L6 3H3M9 20a1 1 0 1 1-2 0a1 1 0 0 1 2 0ZM20 20a1 1 0 1 1-2 0a1 1 0 0 1 2 0Z" />
                             </svg>
 
-                            <span class="absolute -top-1 -right-1 min-w-[1.25rem] h-5 px-1 rounded-full text-xs font-medium
+                            <span id="cart-count-desktop" class="absolute -top-1 -right-1 min-w-[1.25rem] h-5 px-1 rounded-full text-xs font-medium
             bg-amber-300 text-gray-900 grid place-items-center ring-1 ring-black/10
             transition duration-150">
                                 @((ViewBag.CartCount is int c && c > 99) ? "99+" : (ViewBag.CartCount ?? 0).ToString())


### PR DESCRIPTION
## Summary
- add EF Core cart repository and DI registration
- handle HTMX cart additions and return updated count
- mark navbar cart counters for HTMX out-of-band updates

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4702e950883208a2ab56c5b3d5965