### PR TITLE
Ensure case-insensitive product search

### DIFF
--- a/ECommerceBatteryShop.DataAccess/Concrete/ProductRepository.cs
+++ b/ECommerceBatteryShop.DataAccess/Concrete/ProductRepository.cs
@@ -56,38 +56,35 @@ namespace ECommerceBatteryShop.DataAccess.Concrete
         }
         public async Task<List<Product>> ProductSearchResultAsync(string searchTerm)
         {
-         
-                IQueryable<Product> query = _ctx.Products;
+            IQueryable<Product> query = _ctx.Products.AsNoTracking();
+
             if (!string.IsNullOrWhiteSpace(searchTerm))
             {
-                query = query.Where(b => EF.Functions.Like(b.Name, $"%{searchTerm}%"));
+                var term = searchTerm.ToLowerInvariant();
+                query = query.Where(b => b.Name.ToLower().Contains(term));
             }
 
             return await query
                 .Take(100) // or use paging parameters
                 .ToListAsync();
         }
-        
 
         public async Task<List<string>> ProductSearchQueryResultAsync(string searchTerm)
         {
-         
-                IQueryable<Product> query = _ctx.Products;
+            IQueryable<Product> query = _ctx.Products.AsNoTracking();
+
             if (!string.IsNullOrWhiteSpace(searchTerm))
             {
-                query = query.Where(b => EF.Functions.Like(b.Name, $"%{searchTerm}%"));
+                var term = searchTerm.ToLowerInvariant();
+                query = query.Where(b => b.Name.ToLower().Contains(term));
             }
-            foreach (var name in query)
-            {
-                Console.WriteLine(name);
-            }
-            var results = await query
-    .Select(b => b.Name)
-    .Distinct()
-    .OrderBy(n => n)
-    .Take(20)
-    .ToListAsync();
-            return results;
+
+            return await query
+                .Select(b => b.Name)
+                .Distinct()
+                .OrderBy(n => n)
+                .Take(20)
+                .ToListAsync();
         }
         public async Task<IReadOnlyList<Product>> BringProductsByCategoryIdAsync(
       int categoryId,

--- a/ECommerceBatteryShop/Controllers/ProductController.cs
+++ b/ECommerceBatteryShop/Controllers/ProductController.cs
@@ -63,16 +63,8 @@ namespace ECommerceBatteryShop.Controllers
 
             return View("Details", vm); // full view under _Layout
         }
-        public async Task<IActionResult> Search([FromQuery] string? q, CancellationToken ct)
-        {
-            // Use your lightweight names query (autocomplete)
-            var names = await _repo.ProductSearchQueryResultAsync(q ?? string.Empty);
-            // Render as HTML (partial)
-            return PartialView("_ProductNames", names);
-        }
-
         [HttpGet("/Product/Search")]
-        public async Task<IActionResult> Search([FromQuery] string q)
+        public async Task<IActionResult> Search([FromQuery] string q, CancellationToken ct = default)
         {
             var names = await _repo.ProductSearchQueryResultAsync(q ?? string.Empty);
             return PartialView("_ProductPredictions", names);


### PR DESCRIPTION
## Summary
- Ensure search queries match product names regardless of case and avoid tracking in EF queries
- Consolidate product search endpoint into a single action for autocomplete predictions

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd8f886588320a52a34adf1e790df