### PR TITLE
Enable search button HTMX query

### DIFF
--- a/ECommerceBatteryShop/Controllers/ProductController.cs
+++ b/ECommerceBatteryShop/Controllers/ProductController.cs
@@ -17,10 +17,14 @@ namespace ECommerceBatteryShop.Controllers
 
         }
 
-        public async Task<IActionResult> Index(int? categoryId, CancellationToken ct)
+        public async Task<IActionResult> Index(int? categoryId, string? q, CancellationToken ct)
         {
             IReadOnlyList<Product> products;
-            if (categoryId.HasValue && categoryId > 0)
+            if (!string.IsNullOrWhiteSpace(q))
+            {
+                products = await _repo.ProductSearchResultAsync(q);
+            }
+            else if (categoryId.HasValue && categoryId > 0)
             {
                 products = await _repo.BringProductsByCategoryIdAsync(categoryId.Value, ct: ct);
             }

--- a/ECommerceBatteryShop/Views/Shared/_Layout.cshtml
+++ b/ECommerceBatteryShop/Views/Shared/_Layout.cshtml
@@ -44,7 +44,11 @@
                                class="flex-1 pl-10 pr-10 text-black placeholder-gray-500 focus:outline-none w-full" />
 
                         <!-- Submit button -->
-                        <button type="submit" aria-label="Search"
+                        <button type="button" aria-label="Search"
+                                hx-get="/Product/Search"
+                                hx-include="[name='q']"
+                                hx-target="#search-predictions-mobile"
+                                hx-indicator="#search-spinner"
                                 class="absolute right-0 top-0 h-full px-3 bg-amber-300 hover:bg-amber-400 grid place-items-center">
                             <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
                                 <circle cx="9.14" cy="9.14" r="7.64" stroke="#020202" stroke-width="1.9"></circle>
@@ -138,7 +142,11 @@
                                        class="w-full pl-10 pr-10 text-black placeholder-gray-500 focus:outline-none h-10" />
 
                                 <!-- Submit button -->
-                                <button type="submit" aria-label="Search"
+                                <button type="button" aria-label="Search"
+                                        hx-get="/Product/Search"
+                                        hx-include="[name='q']"
+                                        hx-target="#search-predictions-desktop"
+                                        hx-indicator="#search-spinner-desktop"
                                         class="absolute cursor-pointer right-0 top-0 rounded-r-lg h-10 px-3 bg-amber-300 hover:bg-amber-400 grid place-items-center">
                                     <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
                                         <circle cx="9.14" cy="9.14" r="7.64" stroke="#020202" stroke-width="1.9"></circle>

--- a/ECommerceBatteryShop/Views/Shared/_Layout.cshtml
+++ b/ECommerceBatteryShop/Views/Shared/_Layout.cshtml
@@ -21,8 +21,7 @@
             <div class="mx-auto max-w-7xl px-4 h-14 flex items-center gap-3 py-6">
                 <!-- Search -->
                 <div class="flex-1">
-                    <div class="relative h-10 rounded-lg border border-gray-300 bg-white overflow-hidden
-              focus-within:ring-2 focus-within:ring-amber-400 focus-within:border-amber-400">
+                    <form method="get" action="/Product/Index" class="relative h-10 rounded-lg border border-gray-300 bg-white overflow-hidden focus-within:ring-2 focus-within:ring-amber-400 focus-within:border-amber-400">
 
                         <!-- Search icon -->
                         <svg class="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-500 pointer-events-none"
@@ -37,18 +36,14 @@
                                type="search"
                                placeholder="Ara..."
                                hx-get="/Product/Search"
-                               hx-trigger="keyup changed delay:300ms, search"
+                               hx-trigger="keyup changed delay:300ms"
                                hx-target="#search-predictions-mobile"
                                hx-indicator="#search-spinner"
                                autocomplete="off"
                                class="flex-1 pl-10 pr-10 text-black placeholder-gray-500 focus:outline-none w-full" />
 
                         <!-- Submit button -->
-                        <button type="button" aria-label="Search"
-                                hx-get="/Product/Search"
-                                hx-include="[name='q']"
-                                hx-target="#search-predictions-mobile"
-                                hx-indicator="#search-spinner"
+                        <button type="submit" aria-label="Search"
                                 class="absolute right-0 top-0 h-full px-3 bg-amber-300 hover:bg-amber-400 grid place-items-center">
                             <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
                                 <circle cx="9.14" cy="9.14" r="7.64" stroke="#020202" stroke-width="1.9"></circle>
@@ -62,7 +57,7 @@
                   rounded-b-2xl shadow-2xl bg-white text-black z-70 hidden">
                             <!-- HTMX injects results here -->
                         </div>
-                    </div>
+                    </form>
                 </div>
 
 
@@ -119,8 +114,7 @@
                         <div class="relative">
 
                             <!-- Input box -->
-                            <div class="h-10 rounded-md border border-gray-300 bg-white overflow-hidden
-                focus-within:ring-2 focus-within:ring-amber-400 focus-within:border-amber-400">
+                            <form method="get" action="/Product/Index" class="h-10 rounded-md border border-gray-300 bg-white overflow-hidden focus-within:ring-2 focus-within:ring-amber-400 focus-within:border-amber-400">
 
                                 <!-- Search icon -->
                                 <svg class="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-500 pointer-events-none"
@@ -134,7 +128,7 @@
                                        type="search"
                                        placeholder="Ara..."
                                        hx-get="/Product/Search"
-                                       hx-trigger="keyup changed delay:300ms, search"
+                                       hx-trigger="keyup changed delay:300ms"
                                        hx-target="#search-predictions-desktop"
                                        hx-indicator="#search-spinner-desktop"
                                        autocomplete="off"
@@ -142,11 +136,7 @@
                                        class="w-full pl-10 pr-10 text-black placeholder-gray-500 focus:outline-none h-10" />
 
                                 <!-- Submit button -->
-                                <button type="button" aria-label="Search"
-                                        hx-get="/Product/Search"
-                                        hx-include="[name='q']"
-                                        hx-target="#search-predictions-desktop"
-                                        hx-indicator="#search-spinner-desktop"
+                                <button type="submit" aria-label="Search"
                                         class="absolute cursor-pointer right-0 top-0 rounded-r-lg h-10 px-3 bg-amber-300 hover:bg-amber-400 grid place-items-center">
                                     <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
                                         <circle cx="9.14" cy="9.14" r="7.64" stroke="#020202" stroke-width="1.9"></circle>
@@ -159,7 +149,7 @@
                                       class="htmx-indicator absolute right-12 top-1/2 -translate-y-1/2 text-gray-500 hidden">
                                     Yükleniyor...
                                 </span>
-                            </div>
+                            </form>
                             <!-- Predictions dropdown (sibling, not inside input box) -->
                             <div id="search-predictions-desktop"
                                  class="absolute top-full left-0 w-full max-h-104 overflow-y-auto


### PR DESCRIPTION
## Summary
- Trigger HTMX product search when clicking the search button on mobile and desktop layouts

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bece95dba8832092c9fe9ed91b3e00