### PR TITLE
Fix search input query parameter mapping

### DIFF
--- a/ECommerceBatteryShop/Controllers/ProductController.cs
+++ b/ECommerceBatteryShop/Controllers/ProductController.cs
@@ -17,12 +17,14 @@ namespace ECommerceBatteryShop.Controllers
 
         }
 
-        public async Task<IActionResult> Index(string? search, int? categoryId, CancellationToken ct)
+        public async Task<IActionResult> Index(string? search, string? q, int? categoryId, CancellationToken ct)
         {
+            var term = search ?? q;
+
             IReadOnlyList<Product> products;
-            if (!string.IsNullOrWhiteSpace(search))
+            if (!string.IsNullOrWhiteSpace(term))
             {
-                products = await _repo.ProductSearchResultAsync(search);
+                products = await _repo.ProductSearchResultAsync(term);
             }
             else if (categoryId.HasValue && categoryId > 0)
             {


### PR DESCRIPTION
## Summary
- Accept both `search` and `q` query parameters in `ProductController.Index` and use whichever is provided

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd40549e88320852f3fe9f6ea4c18