### PR TITLE
Hide empty categories from navigation menu

### DIFF
--- a/ECommerceBatteryShop.DataAccess/Concrete/CategoryRepository.cs
+++ b/ECommerceBatteryShop.DataAccess/Concrete/CategoryRepository.cs
@@ -18,7 +18,9 @@ public sealed class CategoryRepository : ICategoryRepository
         return await _ctx.Categories
             .AsNoTracking()
             .Where(c => c.ParentCategoryId == null)
+            .Include(c => c.ProductCategories)
             .Include(c => c.SubCategories)
+                .ThenInclude(sc => sc.ProductCategories)
             .OrderBy(c => c.Name)
             .ToListAsync(ct);
     }

--- a/ECommerceBatteryShop/Views/Shared/_Layout.cshtml
+++ b/ECommerceBatteryShop/Views/Shared/_Layout.cshtml
@@ -1,7 +1,16 @@
 @using ECommerceBatteryShop.Domain.Entities
+@using System.Linq
 @inject ECommerceBatteryShop.DataAccess.Abstract.ICategoryRepository CategoryRepository
 @{
     var categories = await CategoryRepository.GetCategoriesWithChildrenAsync();
+    categories = categories
+        .Where(c => c.ProductCategories.Any() || c.SubCategories.Any(sc => sc.ProductCategories.Any()))
+        .Select(c =>
+        {
+            c.SubCategories = c.SubCategories.Where(sc => sc.ProductCategories.Any()).ToList();
+            return c;
+        })
+        .ToList();
 }
 ﻿<!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary
- Load product mappings for categories
- Filter navigation categories to only show those with products

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden repository)*

------
https://chatgpt.com/codex/tasks/task_e_68c133cf39108320af2bbe2ce3c7d0cc