### PR TITLE
Add checkout page with amber CTA

### DIFF
--- a/ECommerceBatteryShop/Controllers/CartController.cs
+++ b/ECommerceBatteryShop/Controllers/CartController.cs
@@ -21,6 +21,12 @@ namespace ECommerceBatteryShop.Controllers
             return View();
         }
 
+        [HttpGet]
+        public IActionResult Checkout()
+        {
+            return View();
+        }
+
         [HttpPost]
         [ValidateAntiForgeryToken]
         public async Task<IActionResult> Add(int productId, int quantity = 1, CancellationToken ct = default)

--- a/ECommerceBatteryShop/Views/Cart/Checkout.cshtml
+++ b/ECommerceBatteryShop/Views/Cart/Checkout.cshtml
@@ -1,5 +1,17 @@
-﻿@*
-    For more information on enabling MVC for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
-*@
 @{
+    ViewBag.Title = "Checkout";
 }
+
+<main class="bg-white min-h-screen pt-28 pb-24">
+    <div class="mx-auto max-w-3xl px-4">
+        <h1 class="text-2xl font-semibold text-slate-900 mb-6">Ödeme</h1>
+        <div class="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+            <p class="text-slate-700 mb-4">
+                Siparişinizi tamamlamak için aşağıdaki butonu kullanabilirsiniz.
+            </p>
+            <a href="#" class="mt-2 inline-flex h-12 w-full items-center justify-center rounded-xl bg-amber-300 font-semibold text-gray-900 shadow-sm hover:bg-amber-400 focus:outline-none focus:ring-4 focus:ring-amber-100 transition">
+                Ödemeye Devam Et
+            </a>
+        </div>
+    </div>
+</main>

--- a/ECommerceBatteryShop/Views/Cart/Index.cshtml
+++ b/ECommerceBatteryShop/Views/Cart/Index.cshtml
@@ -115,9 +115,9 @@
                 </dl>
 
 
-                <button class="mt-4 w-full h-12 rounded-xl bg-amber-300 font-semibold hover:bg-amber-400 shadow-sm focus:outline-none focus:ring-4 focus:ring-slate-200 transition hover:shadow-md" id="pay">
+                <a href="/Cart/Checkout" class="mt-4 w-full h-12 inline-flex items-center justify-center rounded-xl bg-amber-300 font-semibold hover:bg-amber-400 shadow-sm focus:outline-none focus:ring-4 focus:ring-slate-200 transition hover:shadow-md">
                     Güvenli Ödeme
-                </button>
+                </a>
                 <p class="mt-2 text-xs text-slate-500 text-center">3D Secure desteklenir</p>
             </aside>
         </div>


### PR DESCRIPTION
## Summary
- add checkout action and view featuring amber-300 call-to-action on white background
- wire cart summary button to checkout page

## Testing
- `dotnet build` *(failed: command not found)*
- `apt-get update` *(failed: 403 Forbidden)*
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c46010bb908320b1d196cfc558bc96