### PR TITLE
Fix cart item deletion not triggering

### DIFF
--- a/ECommerceBatteryShop/Views/Cart/Index.cshtml
+++ b/ECommerceBatteryShop/Views/Cart/Index.cshtml
@@ -65,7 +65,7 @@
                                     </div>
                                     <button
                                         hx-post="/Cart/Delete"
-                                        hx-vals='js:{ productId: item.id }'
+                                        :hx-vals="JSON.stringify({ productId: item.id })"
                                         hx-swap="none"
                                         hx-on:htmx:afterRequest="remove(item.id)"
                                         class="text-slate-400 hover:text-slate-700" aria-label="Kaldır" title="Kaldır">


### PR DESCRIPTION
## Summary
- bind product id dynamically when sending HTMX delete requests from cart items

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6d84241c88320b5fae80cbb2c1cbf