### PR TITLE
Add tablet navbar layout

### DIFF
--- a/ECommerceBatteryShop/Views/Shared/_CartCount.cshtml
+++ b/ECommerceBatteryShop/Views/Shared/_CartCount.cshtml
@@ -7,3 +7,4 @@
 
 <span id="cart-count-desktop" hx-swap-oob="innerHTML">@text</span>
 <span id="cart-count-mobile" hx-swap-oob="innerHTML">@text</span>
+<span id="cart-count-tablet" hx-swap-oob="innerHTML">@text</span>

--- a/ECommerceBatteryShop/Views/Shared/_Layout.cshtml
+++ b/ECommerceBatteryShop/Views/Shared/_Layout.cshtml
@@ -136,11 +136,159 @@
                  @@click="overlay=false"></div>
 
         <!-- add this -->
-        <!-- NAVBAR -->
-
+        <!-- TABLET NAVBAR -->
         <nav x-data="{ scrolled:false }"
              @@scroll.window.passive ="scrolled = window.scrollY > 0"
-             class="fixed top-0 inset-x-0 z-50 bg-gray-900 text-white hidden sm:block transition-shadow duration-200 h-20"
+             class="fixed top-0 inset-x-0 z-50 bg-gray-900 text-white hidden md:block lg:hidden transition-shadow duration-200 h-20"
+             :class="scrolled ? 'shadow-md bg-gray-900/90 backdrop-blur' : ''">
+            <div class="mx-auto max-w-[95%] px-4 h-full flex items-center gap-6">
+                <!-- Logo -->
+                <div>
+                    <a href="/Home/Index"
+                       class="flex-none text-xl font-bold hover:text-gray-300">
+                        <img src="~/img/logo.png" alt="Logo" class="h-16 w-auto object-contain" />
+                    </a>
+
+                </div>
+
+                <!-- Search -->
+                    <div class="flex-1">
+                        <!-- wrapper controls positioning -->
+                        <div class="relative">
+
+                            <!-- Input box -->
+                            <form method="get" action="/Product/Index" class="h-10 rounded-md border border-gray-300 bg-white overflow-hidden focus-within:ring-2 focus-within:ring-amber-400 focus-within:border-amber-400">
+
+                                <!-- Search icon -->
+                                <svg class="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-500 pointer-events-none"
+                                     xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <circle cx="11" cy="11" r="7" stroke-width="2" />
+                                    <path d="M21 21l-4.3-4.3" stroke-width="2" />
+                                </svg>
+
+                                <!-- Input -->
+                                <input name="q"
+                                       type="search"
+                                       placeholder="Ara..."
+                                       hx-get="/Product/Search"
+                                       hx-trigger="keyup changed delay:300ms"
+                                       hx-target="#search-predictions-tablet"
+                                       hx-indicator="#search-spinner-tablet"
+                                       autocomplete="off"
+                                       @@focus="overlay=true" @@blur="overlay=false"
+                                       class="w-full pl-10 pr-10 text-black placeholder-gray-500 focus:outline-none h-10" />
+
+                                <!-- Submit button -->
+                                <button type="submit" aria-label="Search"
+                                        class="absolute cursor-pointer right-0 top-0 rounded-r-lg h-10 px-3 bg-amber-300 hover:bg-amber-400 grid place-items-center">
+                                    <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none">
+                                        <circle cx="9.14" cy="9.14" r="7.64" stroke="#020202" stroke-width="1.9"></circle>
+                                        <line x1="22.5" y1="22.5" x2="14.39" y2="14.39" stroke="#020202" stroke-width="1.9"></line>
+                                    </svg>
+                                </button>
+
+                                <!-- Spinner -->
+                                <span id="search-spinner-tablet"
+                                      class="htmx-indicator absolute right-12 top-1/2 -translate-y-1/2 text-gray-500 hidden">
+                                    Yükleniyor...
+                                </span>
+                            </form>
+                            <!-- Predictions dropdown (sibling, not inside input box) -->
+                            <div id="search-predictions-tablet"
+                                 class="absolute top-full left-0 w-full max-h-104 overflow-y-auto
+            rounded-md shadow-2xl bg-white text-black z-50 hidden"
+                                 hx-swap="innerHTML"
+                                 hx-on:htmx:afterSwap="this.classList.toggle('hidden', this.innerHTML.trim()==='')">
+                            </div>
+
+                        </div>
+                    </div>
+
+
+                <div class="flex gap-3">
+                <!-- Cart -->
+                    <!-- Sepet -->
+                    <a href="/Cart/Index" aria-label="Sepet (@cartText ürün)"
+                       class="group relative inline-flex items-center gap-2 h-16 px-4 shrink-0 rounded-md
+   transition duration-150 cursor-pointer hover:bg-white/5 hover:scale-105
+   focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400">
+
+                        <span class="relative inline-flex">
+                            <svg xmlns="http://www.w3.org/2000/svg"
+                                 class="h-8 w-8 text-white transition-colors duration-150 group-hover:text-amber-300"
+                                 viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                 stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M6.3 5H21L19 12H7.38M20 16H8L6 3H3M9 20a1 1 0 1 1-2 0a1 1 0 0 1 2 0ZM20 20a1 1 0 1 1-2 0a1 1 0 0 1 2 0Z" />
+                            </svg>
+
+                            <span id="cart-count-tablet" class="absolute -top-1 -right-1 min-w-[1.25rem] h-5 px-1 rounded-full text-xs font-medium
+            bg-amber-300 text-gray-900 grid place-items-center ring-1 ring-black/10
+            transition duration-150">
+                                    @cartText
+                            </span>
+                        </span>
+
+                        <span class="text-white text-md font-semibold transition-colors duration-150 group-hover:text-amber-300">
+                            Sepetim
+                        </span>
+                    </a>
+
+                    <!-- Favoriler -->
+                    <a href="/Favorites/Index"aria-label="Favoriler"
+                       class="group relative inline-flex items-center gap-2 h-16 px-4 shrink-0 rounded-md
+   transition duration-150 cursor-pointer hover:bg-white/5 hover:scale-105
+   focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-300">
+
+                        <span class="relative inline-flex">
+                            <svg class="h-8 w-8 text-white transition-colors duration-150 group-hover:text-amber-300"
+                                 viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                <path fill-rule="evenodd" clip-rule="evenodd"
+                                      d="M11.993 5.09691C11.0387 4.25883 9.78328 3.75 8.40796 3.75C5.42122 3.75 3 6.1497 3 9.10988C3 10.473 3.50639 11.7242 4.35199 12.67L12 20.25L19.4216 12.8944L19.641 12.6631C20.4866 11.7172 21 10.473 21 9.10988C21 6.1497 18.5788 3.75 15.592 3.75C14.2167 3.75 12.9613 4.25883 12.007 5.09692L12 5.08998L11.993 5.09691ZM12 7.09938L12.0549 7.14755L12.9079 6.30208L12.9968 6.22399C13.6868 5.61806 14.5932 5.25 15.592 5.25C17.763 5.25 19.5 6.99073 19.5 9.10988C19.5 10.0813 19.1385 10.9674 18.5363 11.6481L18.3492 11.8453L12 18.1381L5.44274 11.6391C4.85393 10.9658 4.5 10.0809 4.5 9.10988C4.5 6.99073 6.23699 5.25 8.40796 5.25C9.40675 5.25 10.3132 5.61806 11.0032 6.22398L11.0921 6.30203L11.9452 7.14752L12 7.09938Z" />
+                            </svg>
+
+                            <span class="absolute -top-1 -right-1 min-w-[1.25rem] h-5 px-1 rounded-full text-xs font-medium
+            bg-amber-300 text-gray-900 grid place-items-center ring-1 ring-black/10
+            transition duration-150">
+                                @((ViewBag.FavoriteCount is int f && f > 99) ? "99+" : (ViewBag.FavoriteCount ?? 0).ToString())
+                            </span>
+                        </span>
+
+                        <span class="text-white text-md font-semibold transition-colors duration-150 group-hover:text-amber-300">
+                            Favoriler
+                        </span>
+                    </a>
+
+                <!-- Account / Profile -->
+                    <a href="/Account/Register" aria-label="Profil"
+                       class="group inline-flex items-center justify-center px-4 h-16 cursor-pointer rounded-md
+   transition hover:bg-white/10 hover:scale-105 focus-visible:outline-none
+   focus-visible:ring-2 focus-visible:ring-amber-400">
+                        <div class="relative inline-flex transition-transform duration-200">
+                            <svg xmlns="http://www.w3.org/2000/svg"
+                                 class="h-8 w-8 text-white transition-colors duration-200 group-hover:text-amber-300"
+                                 viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                                 stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M16 7a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z" />
+                                <path d="M4 21v-2a4 4 0 0 1 4-4h8a4 4 0 0 1 4 4v2" />
+                            </svg>
+                        </div>
+                        <span class="ml-2 text-white text-md font-semibold transition-colors duration-200 group-hover:text-amber-300">
+                            Üye ol
+                        </span>
+                    </a>
+
+
+
+            </div>
+                <!-- Favorites -->
+
+            </div>
+        </nav>
+
+        <!-- DESKTOP NAVBAR -->
+        <nav x-data="{ scrolled:false }"
+             @@scroll.window.passive ="scrolled = window.scrollY > 0"
+             class="fixed top-0 inset-x-0 z-50 bg-gray-900 text-white hidden lg:block transition-shadow duration-200 h-20"
              :class="scrolled ? 'shadow-md bg-gray-900/90 backdrop-blur' : ''">
             <div class="mx-auto max-w-[95%] px-4 h-full flex items-center gap-10">
                 <!-- Logo -->

--- a/ECommerceBatteryShop/wwwroot/js/layout.js
+++ b/ECommerceBatteryShop/wwwroot/js/layout.js
@@ -8,16 +8,17 @@ document.body.addEventListener('htmx:configRequest', e => {
 
 document.body.addEventListener('htmx:afterSwap', e => {
   const el = e.target;
-    if (!el.id) return;
+  if (!el.id) return;
 
-    if (el.id === 'search-predictions-desktop' || el.id === 'search-predictions-mobile') {
+  const ids = ['search-predictions-desktop', 'search-predictions-mobile', 'search-predictions-tablet'];
+  if (ids.includes(el.id)) {
     const empty = el.innerHTML.trim() === '';
     el.classList.toggle('hidden', empty);
   }
 });
 
 (function () {
-    const ids = ['search-predictions-desktop', 'search-predictions-mobile'];
+    const ids = ['search-predictions-desktop', 'search-predictions-mobile', 'search-predictions-tablet'];
     const dd = () => ids.map(id => document.getElementById(id)).filter(Boolean);
     const hide = () => dd().forEach(el => el.classList.add('hidden'));
     const showIfNotEmpty = el => el.classList.toggle('hidden', el.innerHTML.trim() === '');
@@ -32,9 +33,9 @@ document.body.addEventListener('htmx:afterSwap', e => {
     if (overlay) overlay.addEventListener('click', hide);
 
     // 3) Hide on click outside navbar
-    const navbar = document.querySelector('nav'); // your main navbar
+    const navbars = document.querySelectorAll('nav');
     document.addEventListener('click', ev => {
-        if (!navbar || !navbar.contains(ev.target)) hide();
+        if (![...navbars].some(nav => nav.contains(ev.target))) hide();
     });
 
     // 4) Hide on ESC
@@ -48,7 +49,7 @@ document.body.addEventListener('htmx:afterSwap', e => {
 
 
 (function () {
-    const ids = ['search-predictions-desktop', 'search-predictions-mobile'];
+    const ids = ['search-predictions-desktop', 'search-predictions-mobile', 'search-predictions-tablet'];
     const dd = () => ids.map(id => document.getElementById(id)).filter(Boolean);
     const hide = () => dd().forEach(el => el.classList.add('hidden'));
     const showIfNotEmpty = el => el.classList.toggle('hidden', el.innerHTML.trim() === '');
@@ -93,7 +94,9 @@ document.body.addEventListener('htmx:afterSwap', e => {
     const overlay = document.getElementById('overlay');
     if (overlay) overlay.addEventListener('click', hide);
 
-    const navbar = document.querySelector('nav');
-    document.addEventListener('click', ev => { if (!navbar || !navbar.contains(ev.target)) hide(); });
+    const navbars = document.querySelectorAll('nav');
+    document.addEventListener('click', ev => {
+        if (![...navbars].some(nav => nav.contains(ev.target))) hide();
+    });
     document.addEventListener('keydown', ev => { if (ev.key === 'Escape') hide(); });
 })();


### PR DESCRIPTION
## Summary
- Add tablet-specific navbar for medium screens with search, cart, favorites, and profile links
- Restrict desktop navbar to large screens
- Update cart count partial and layout.js for tablet IDs and multi-navbar handling

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `npm test` *(fails: no test specified)*
- `npm run tw:build` *(fails: 403 Forbidden fetching @tailwindcss/cli)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ddc32d6c832099be88682dac0206