### PR TITLE
Fix data protection persistence for Google login

### DIFF
--- a/ECommerceBatteryShop.DataAccess/BatteryShopContext.cs
+++ b/ECommerceBatteryShop.DataAccess/BatteryShopContext.cs
@@ -1,15 +1,11 @@
 ﻿using ECommerceBatteryShop.Domain.Entities;
-using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 
 namespace ECommerceBatteryShop.DataAccess;
 
-public sealed class BatteryShopContext : DbContext, IDataProtectionKeyContext
+public sealed class BatteryShopContext : DbContext
 {
     public BatteryShopContext(DbContextOptions<BatteryShopContext> options) : base(options) { }
-
-    // REQUIRED for Data Protection persistence
-   public DbSet<DataProtectionKey> DataProtectionKeys { get; set; } = null!;
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {

--- a/ECommerceBatteryShop.DataAccess/DataProtectionKeyContext.cs
+++ b/ECommerceBatteryShop.DataAccess/DataProtectionKeyContext.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.AspNetCore.DataProtection.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+
+namespace ECommerceBatteryShop.DataAccess;
+
+/// <summary>
+/// Dedicated DbContext for persisting ASP.NET Core data protection keys.
+/// Keeping it separate from the main application context avoids schema
+/// verification side-effects when the key repository initialises.
+/// </summary>
+public sealed class DataProtectionKeyContext : DbContext, IDataProtectionKeyContext
+{
+    public DataProtectionKeyContext(DbContextOptions<DataProtectionKeyContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<DataProtectionKey> DataProtectionKeys { get; set; } = null!;
+}


### PR DESCRIPTION
## Summary
- add a dedicated `DataProtectionKeyContext` for the ASP.NET Core data protection key store
- register the new context in Program.cs and ensure the key table exists on startup
- guard against missing database connection strings when configuring the contexts

## Testing
- not run (dotnet CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d23ca7bb6083208e00fce0fb5bae01