### PR TITLE
Add CSP middleware and annotate scripts with nonces

### DIFF
--- a/ECommerceBatteryShop/Program.cs
+++ b/ECommerceBatteryShop/Program.cs
@@ -6,6 +6,7 @@ using ECommerceBatteryShop.DataAccess.Abstract;
 using ECommerceBatteryShop.DataAccess.Concrete;
 using ECommerceBatteryShop.Domain.Entities;
 using ECommerceBatteryShop.Options;
+using ECommerceBatteryShop.Security;
 using ECommerceBatteryShop.Services;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
@@ -30,6 +31,8 @@ builder.Services.AddScoped<ICategoryRepository, CategoryRepository>();
 builder.Services.AddScoped<IUserService, UserService>();
 builder.Services.AddScoped<ICartService, CartService>();
 builder.Services.AddScoped<IFavoritesService, FavoritesService>();
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddScoped<ICspNonceService, CspNonceService>();
 builder.Services.AddMemoryCache();
 
 // ------------------------- Options -------------------------
@@ -186,6 +189,8 @@ var fh = new ForwardedHeadersOptions
 fh.KnownNetworks.Clear();
 fh.KnownProxies.Clear();
 app.UseForwardedHeaders(fh);
+
+app.UseContentSecurityPolicy();
 
 app.UseHsts();
 app.UseHttpsRedirection();

--- a/ECommerceBatteryShop/Security/CspNonceService.cs
+++ b/ECommerceBatteryShop/Security/CspNonceService.cs
@@ -1,0 +1,86 @@
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace ECommerceBatteryShop.Security;
+
+public interface ICspNonceService
+{
+    string ScriptNonce { get; }
+    string StyleNonce { get; }
+}
+
+public sealed class CspNonceService(IHttpContextAccessor httpContextAccessor) : ICspNonceService
+{
+    private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
+
+    public string ScriptNonce => GetNonce(CspKeys.Script);
+
+    public string StyleNonce => GetNonce(CspKeys.Style);
+
+    private string GetNonce(object key)
+    {
+        var context = _httpContextAccessor.HttpContext
+            ?? throw new InvalidOperationException("No active HttpContext to resolve CSP nonces.");
+
+        if (context.Items[key] is string nonce)
+        {
+            return nonce;
+        }
+
+        throw new InvalidOperationException(
+            "CSP nonces are not available. Ensure UseContentSecurityPolicy() runs before rendering views.");
+    }
+}
+
+public static class CspApplicationBuilderExtensions
+{
+    public static IApplicationBuilder UseContentSecurityPolicy(this IApplicationBuilder app)
+    {
+        return app.Use(async (context, next) =>
+        {
+            var scriptNonce = GenerateNonce();
+            var styleNonce = GenerateNonce();
+
+            context.Items[CspKeys.Script] = scriptNonce;
+            context.Items[CspKeys.Style] = styleNonce;
+
+            context.Response.OnStarting(() =>
+            {
+                var policies = new[]
+                {
+                    "default-src 'self'",
+                    $"script-src 'self' 'nonce-{scriptNonce}' 'unsafe-eval' https://cdn.jsdelivr.net https://unpkg.com https://accounts.google.com https://apis.google.com",
+                    $"style-src 'self' 'nonce-{styleNonce}' 'unsafe-inline' https://fonts.googleapis.com",
+                    "img-src 'self' data: https://cdn.jsdelivr.net https://images.unsplash.com https://lh3.googleusercontent.com https://*.googleusercontent.com",
+                    "font-src 'self' https://fonts.gstatic.com",
+                    "connect-src 'self'",
+                    "frame-src 'self' https://accounts.google.com",
+                    "form-action 'self' https://accounts.google.com"
+                };
+
+                context.Response.Headers["Content-Security-Policy"] = string.Join("; ", policies);
+                context.Response.Headers["Referrer-Policy"] = "strict-origin-when-cross-origin";
+                context.Response.Headers["X-Content-Type-Options"] = "nosniff";
+                context.Response.Headers["X-Frame-Options"] = "DENY";
+
+                return Task.CompletedTask;
+            });
+
+            await next();
+        });
+    }
+
+    private static string GenerateNonce()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        RandomNumberGenerator.Fill(buffer);
+        return Convert.ToBase64String(buffer);
+    }
+}
+
+internal static class CspKeys
+{
+    public static readonly object Script = new();
+    public static readonly object Style = new();
+}

--- a/ECommerceBatteryShop/Views/Account/ForgotPassword.cshtml
+++ b/ECommerceBatteryShop/Views/Account/ForgotPassword.cshtml
@@ -27,5 +27,5 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+    <script nonce="@Csp.ScriptNonce" src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
 

--- a/ECommerceBatteryShop/Views/Admin/Index.cshtml
+++ b/ECommerceBatteryShop/Views/Admin/Index.cshtml
@@ -143,7 +143,7 @@
 </section>
 
 @section Scripts {
-    <script>
+    <script nonce="@Csp.ScriptNonce">
         const imageInput = document.querySelector('input[name="Image"]');
         const imagePreview = document.getElementById('imagePreview');
         const cardPreviewImage = document.getElementById('cardPreviewImage');

--- a/ECommerceBatteryShop/Views/Cart/Checkout.cshtml
+++ b/ECommerceBatteryShop/Views/Cart/Checkout.cshtml
@@ -236,7 +236,7 @@
     </div>
 </div>
 
-<script>
+<script nonce="@Csp.ScriptNonce">
     // Basit IBAN kopyalama
     (function () {
       const btn = document.getElementById('copyIban');

--- a/ECommerceBatteryShop/Views/Cart/Index.cshtml
+++ b/ECommerceBatteryShop/Views/Cart/Index.cshtml
@@ -227,7 +227,7 @@ else
 
 </main>
 
-<script>
+<script nonce="@Csp.ScriptNonce">
     function cartPage(initialItems){
       return {
         // config
@@ -324,7 +324,7 @@ else
       }
     }
 </script>
-<style>
+<style nonce="@Csp.StyleNonce">
     input[type=number]::-webkit-inner-spin-button,
     input[type=number]::-webkit-outer-spin-button {
         -webkit-appearance: none;

--- a/ECommerceBatteryShop/Views/Favorites/Index.cshtml
+++ b/ECommerceBatteryShop/Views/Favorites/Index.cshtml
@@ -165,7 +165,7 @@ else
     <!-- If you already emit the token meta in _Layout, keep only the JS below -->
     @inject Microsoft.AspNetCore.Antiforgery.IAntiforgery AF
 
-    <script>
+    <script nonce="@Csp.ScriptNonce">
         // Send antiforgery token with all HTMX requests
         document.body.addEventListener('htmx:configRequest', function (evt) {
             var meta = document.querySelector('meta[name="request-verification-token"]');

--- a/ECommerceBatteryShop/Views/Home/Index.cshtml
+++ b/ECommerceBatteryShop/Views/Home/Index.cshtml
@@ -60,7 +60,7 @@
 </section>
 
 
-<script>
+<script nonce="@Csp.ScriptNonce">
  
 </script>
 
@@ -288,8 +288,8 @@
     </section>
 }
 
-<script src="~/js/anasayfa.js"></script>
-<style>
+<script nonce="@Csp.ScriptNonce" src="~/js/anasayfa.js"></script>
+<style nonce="@Csp.StyleNonce">
 .hide-scrollbar::-webkit-scrollbar {
   display: none;
 }

--- a/ECommerceBatteryShop/Views/Product/Details.cshtml
+++ b/ECommerceBatteryShop/Views/Product/Details.cshtml
@@ -155,7 +155,7 @@
     </div>
 
     </main>
-<style>
+<style nonce="@Csp.StyleNonce">
     input[type=number]::-webkit-inner-spin-button,
     input[type=number]::-webkit-outer-spin-button {
         -webkit-appearance: none;

--- a/ECommerceBatteryShop/Views/Product/Index.cshtml
+++ b/ECommerceBatteryShop/Views/Product/Index.cshtml
@@ -32,7 +32,7 @@
 }
 
 <!-- Include once globally (Layout). Safe if duplicated -->
-<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+<script nonce="@Csp.ScriptNonce" defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 
 
 
@@ -328,7 +328,7 @@ else
     }
 }
 
-<style>
+<style nonce="@Csp.StyleNonce">
     input[type=number]::-webkit-inner-spin-button,
     input[type=number]::-webkit-outer-spin-button {
         -webkit-appearance: none;

--- a/ECommerceBatteryShop/Views/Shared/_AccountLayout.cshtml
+++ b/ECommerceBatteryShop/Views/Shared/_AccountLayout.cshtml
@@ -12,12 +12,12 @@
     <link href="~/css/output.css" rel="stylesheet" />
 
     <!-- Alpine -->
-    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
-    <style>
+    <script nonce="@Csp.ScriptNonce" defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <style nonce="@Csp.StyleNonce">
         [x-cloak] {
             display: none !important
         }</style>
-    <script>
+    <script nonce="@Csp.ScriptNonce">
         document.addEventListener('alpine:init', () => {
           Alpine.data('passwordField', () => ({
             show: false,
@@ -62,7 +62,7 @@
         </div>
     </div>
 
-    <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
+    <script nonce="@Csp.ScriptNonce" src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.browser.min.js"></script>
 </body>
 </html>
 

--- a/ECommerceBatteryShop/Views/Shared/_Layout.cshtml
+++ b/ECommerceBatteryShop/Views/Shared/_Layout.cshtml
@@ -662,9 +662,9 @@
         </div>
     </div>
 
-    <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
-    <script src="https://unpkg.com/htmx.org@1.9.12" defer></script>
-    <script src="~/js/layout.js"></script>
+    <script nonce="@Csp.ScriptNonce" src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
+    <script nonce="@Csp.ScriptNonce" src="https://unpkg.com/htmx.org@1.9.12" defer></script>
+    <script nonce="@Csp.ScriptNonce" src="~/js/layout.js"></script>
     @await RenderSectionAsync("Scripts", required: false)
 </body>
 </html>

--- a/ECommerceBatteryShop/Views/_ViewImports.cshtml
+++ b/ECommerceBatteryShop/Views/_ViewImports.cshtml
@@ -1,3 +1,5 @@
-﻿@using ECommerceBatteryShop
+@using ECommerceBatteryShop
 @using ECommerceBatteryShop.Models
+@using ECommerceBatteryShop.Security
 @addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers
+@inject ICspNonceService Csp


### PR DESCRIPTION
## Summary
- add a CSP middleware that generates per-request script/style nonces and writes strict headers allowing Google OAuth endpoints
- register the nonce service for injection and expose it to Razor views via `_ViewImports`
- tag every inline or external script/style element with the generated nonce so the pages comply with the CSP

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d42b2ddd30832092a7b98ec8dc89d4