### PR TITLE
Implement dynamic address management

### DIFF
--- a/ECommerceBatteryShop/Controllers/AddressController.cs
+++ b/ECommerceBatteryShop/Controllers/AddressController.cs
@@ -1,12 +1,170 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Security.Claims;
+using ECommerceBatteryShop.DataAccess;
+using ECommerceBatteryShop.Domain.Entities;
+using ECommerceBatteryShop.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace ECommerceBatteryShop.Controllers
 {
+    [Authorize]
     public class AddressController : Controller
     {
-        public IActionResult Index()
+        private readonly BatteryShopContext _db;
+
+        public AddressController(BatteryShopContext db)
         {
-            return View();
+            _db = db;
+        }
+
+        private int GetUserId()
+        {
+            var userIdClaim = User.FindFirst("sub") ?? User.FindFirst(ClaimTypes.NameIdentifier);
+            if (userIdClaim == null)
+            {
+                throw new InvalidOperationException("Authenticated user must have an identifier.");
+            }
+
+            if (!int.TryParse(userIdClaim.Value, out var userId))
+            {
+                throw new InvalidOperationException("User identifier is not a valid integer value.");
+            }
+
+            return userId;
+        }
+
+        private static AddressViewModel ToViewModel(Address entity) => AddressViewModel.FromEntity(entity);
+
+        private PartialViewResult RenderAddressList(IEnumerable<Address> addresses)
+        {
+            var viewModel = new AddressListViewModel
+            {
+                ContainerId = "address-list",
+                Addresses = addresses
+                    .OrderByDescending(a => a.IsDefault)
+                    .ThenBy(a => a.Id)
+                    .Select(ToViewModel)
+                    .ToList()
+            };
+
+            return PartialView("~/Views/Address/_AddressList.cshtml", viewModel);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Upsert(AddressInputModel model, CancellationToken ct)
+        {
+            if (!ModelState.IsValid)
+            {
+                return ValidationProblem(ModelState);
+            }
+
+            var userId = GetUserId();
+
+            Address? entity = null;
+            if (model.Id > 0)
+            {
+                entity = await _db.Addresses.FirstOrDefaultAsync(a => a.Id == model.Id && a.UserId == userId, ct);
+                if (entity is null)
+                {
+                    return NotFound();
+                }
+            }
+
+            if (entity is null)
+            {
+                entity = new Address
+                {
+                    UserId = userId
+                };
+                _db.Addresses.Add(entity);
+            }
+
+            entity.Title = model.Title.Trim();
+            entity.Name = model.Name.Trim();
+            entity.Surname = model.Surname.Trim();
+            entity.PhoneNumber = model.PhoneNumber.Trim();
+            entity.FullAddress = model.FullAddress.Trim();
+            entity.City = model.City.Trim();
+            entity.State = model.State.Trim();
+            entity.Country = string.IsNullOrWhiteSpace(model.Country) ? "Türkiye" : model.Country.Trim();
+            entity.Neighbourhood = model.Neighbourhood.Trim();
+
+            if (model.IsDefault)
+            {
+                var otherAddresses = await _db.Addresses
+                    .Where(a => a.UserId == userId && a.Id != entity.Id)
+                    .ToListAsync(ct);
+
+                foreach (var address in otherAddresses)
+                {
+                    address.IsDefault = false;
+                }
+
+                entity.IsDefault = true;
+            }
+            else
+            {
+                entity.IsDefault = false;
+
+                var hasOtherDefault = await _db.Addresses
+                    .AnyAsync(a => a.UserId == userId && a.IsDefault && a.Id != entity.Id, ct);
+
+                if (!hasOtherDefault)
+                {
+                    // Ensure there is always a default address. If none exists, mark the current one.
+                    entity.IsDefault = true;
+                }
+            }
+
+            await _db.SaveChangesAsync(ct);
+
+            var addresses = await _db.Addresses
+                .AsNoTracking()
+                .Where(a => a.UserId == userId)
+                .ToListAsync(ct);
+
+            return RenderAddressList(addresses);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> SetDefault(int id, CancellationToken ct)
+        {
+            var userId = GetUserId();
+
+            var addresses = await _db.Addresses.Where(a => a.UserId == userId).ToListAsync(ct);
+            if (!addresses.Any())
+            {
+                return NotFound();
+            }
+
+            var target = addresses.FirstOrDefault(a => a.Id == id);
+            if (target is null)
+            {
+                return NotFound();
+            }
+
+            foreach (var address in addresses)
+            {
+                address.IsDefault = address.Id == id;
+            }
+
+            await _db.SaveChangesAsync(ct);
+
+            return RenderAddressList(addresses);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> List(CancellationToken ct)
+        {
+            var userId = GetUserId();
+            var addresses = await _db.Addresses
+                .AsNoTracking()
+                .Where(a => a.UserId == userId)
+                .ToListAsync(ct);
+
+            return RenderAddressList(addresses);
         }
     }
 }

--- a/ECommerceBatteryShop/Models/AddressInputModel.cs
+++ b/ECommerceBatteryShop/Models/AddressInputModel.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ECommerceBatteryShop.Models
+{
+    public class AddressInputModel
+    {
+        public int Id { get; set; }
+
+        [Required, MaxLength(128)]
+        public string Title { get; set; } = string.Empty;
+
+        [Required, MaxLength(128)]
+        public string Name { get; set; } = string.Empty;
+
+        [Required, MaxLength(128)]
+        public string Surname { get; set; } = string.Empty;
+
+        [Required, MaxLength(32)]
+        public string PhoneNumber { get; set; } = string.Empty;
+
+        [Required, MaxLength(512)]
+        public string FullAddress { get; set; } = string.Empty;
+
+        [Required, MaxLength(128)]
+        public string City { get; set; } = string.Empty;
+
+        [Required, MaxLength(128)]
+        public string State { get; set; } = string.Empty;
+
+        [MaxLength(128)]
+        public string Country { get; set; } = string.Empty;
+
+        [Required, MaxLength(256)]
+        public string Neighbourhood { get; set; } = string.Empty;
+
+        public bool IsDefault { get; set; }
+    }
+}

--- a/ECommerceBatteryShop/Models/AddressListViewModel.cs
+++ b/ECommerceBatteryShop/Models/AddressListViewModel.cs
@@ -1,0 +1,8 @@
+namespace ECommerceBatteryShop.Models
+{
+    public class AddressListViewModel
+    {
+        public string ContainerId { get; set; } = "address-list";
+        public IReadOnlyList<AddressViewModel> Addresses { get; set; } = Array.Empty<AddressViewModel>();
+    }
+}

--- a/ECommerceBatteryShop/Models/AddressViewModel.cs
+++ b/ECommerceBatteryShop/Models/AddressViewModel.cs
@@ -13,6 +13,27 @@ namespace ECommerceBatteryShop.Models
         public string FullAddress { get; set; } = string.Empty;
         public string City { get; set; } = string.Empty;
         public string State { get; set; } = string.Empty;
-        public string NeightBourhood { get; set; } = string.Empty;
+        public string Country { get; set; } = string.Empty;
+        public string Neighbourhood { get; set; } = string.Empty;
+        public bool IsDefault { get; set; }
+
+        public static AddressViewModel FromEntity(Address entity)
+        {
+            return new AddressViewModel
+            {
+                Id = entity.Id,
+                UserId = entity.UserId,
+                Title = entity.Title,
+                Name = entity.Name,
+                Surname = entity.Surname,
+                PhoneNumber = entity.PhoneNumber,
+                FullAddress = entity.FullAddress,
+                City = entity.City,
+                State = entity.State,
+                Country = entity.Country,
+                Neighbourhood = entity.Neighbourhood,
+                IsDefault = entity.IsDefault
+            };
+        }
     }
 }

--- a/ECommerceBatteryShop/Models/CheckoutViewModel.cs
+++ b/ECommerceBatteryShop/Models/CheckoutViewModel.cs
@@ -1,0 +1,15 @@
+namespace ECommerceBatteryShop.Models
+{
+    public class CheckoutViewModel
+    {
+        public decimal Subtotal { get; set; }
+
+        public AddressListViewModel AddressList { get; set; } = new AddressListViewModel();
+
+        public decimal Tax => Subtotal * 0.2m;
+
+        public decimal Shipping => 150m;
+
+        public decimal Total => Subtotal + Shipping;
+    }
+}

--- a/ECommerceBatteryShop/Views/Account/Profile.cshtml
+++ b/ECommerceBatteryShop/Views/Account/Profile.cshtml
@@ -8,6 +8,8 @@
 
     var displayName = rawName.Replace("-", "").Trim();
 
+    var addressList = ViewBag.AddressList as AddressListViewModel ?? new AddressListViewModel();
+
 
     var orders = new[]
     {
@@ -227,7 +229,7 @@
                             <h2 class="text-lg font-semibold text-gray-900">Adresler & Fatura Bilgileri</h2>
                             <p class="text-sm text-gray-500">Teslimat adreslerinizi ve fatura bilgilerinizi yönetin.</p>
                         </div>
-                        <button type="button" class="inline-flex items-center gap-2 rounded-full border border-amber-200 px-4 py-2 text-sm font-semibold text-amber-600 transition hover:border-amber-300 hover:text-amber-700">
+                        <button type="button" class="inline-flex items-center gap-2 rounded-full border border-amber-200 px-4 py-2 text-sm font-semibold text-amber-600 transition hover:border-amber-300 hover:text-amber-700" @@click="$store.address.openNew()">
                             Yeni adres ekle
                             <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
                                 <path d="M12 5v14" />
@@ -236,24 +238,7 @@
                         </button>
                     </div>
 
-                    <div class="mt-6 grid gap-4 md:grid-cols-2">
-                        <div class="rounded-xl border border-gray-100 p-4">
-                            <p class="text-sm font-semibold text-gray-900">Ev Adresi</p>
-                            <p class="mt-1 text-sm text-gray-600">Ataköy Mah./ İstanbul</p>
-                            <div class="mt-4 flex gap-2 text-xs">
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 transition hover:border-amber-300 hover:text-amber-600">Düzenle</button>
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 transition hover:border-amber-300 hover:text-amber-600">Varsayılan Yap</button>
-                            </div>
-                        </div>
-                        <div class="rounded-xl border border-gray-100 p-4">
-                            <p class="text-sm font-semibold text-gray-900">İş Adresi</p>
-                            <p class="mt-1 text-sm text-gray-600">Teknopark İstanbul</p>
-                            <div class="mt-4 flex gap-2 text-xs">
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 transition hover:border-amber-300 hover:text-amber-600">Düzenle</button>
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 transition hover:border-amber-300 hover:text-amber-600">Varsayılan Yap</button>
-                            </div>
-                        </div>
-                    </div>
+                    @await Html.PartialAsync("~/Views/Address/_AddressList.cshtml", addressList)
                 </section>
 
                 <section id="support" class="rounded-2xl bg-gradient-to-br from-gray-900 via-gray-800 to-black p-6 text-white shadow-sm">
@@ -274,3 +259,10 @@
         </div>
     </div>
 </section>
+
+<style>
+    [x-cloak] {
+        display: none !important
+    }
+</style>
+@await Html.PartialAsync("~/Views/Address/_AddressModal.cshtml", addressList.ContainerId)

--- a/ECommerceBatteryShop/Views/Address/_AddressList.cshtml
+++ b/ECommerceBatteryShop/Views/Address/_AddressList.cshtml
@@ -1,0 +1,59 @@
+@model ECommerceBatteryShop.Models.AddressListViewModel
+
+<div id="@Model.ContainerId" class="mt-6 grid gap-4 md:grid-cols-2">
+    @if (Model.Addresses.Count == 0)
+    {
+        <div class="rounded-xl border border-dashed border-gray-200 p-6 text-center text-sm text-gray-500">
+            Henüz adres eklemediniz.
+        </div>
+    }
+    else
+    {
+        foreach (var address in Model.Addresses)
+        {
+            <div class="rounded-xl border border-gray-100 p-4">
+                <div class="flex items-start justify-between gap-2">
+                    <div>
+                        <p class="text-sm font-semibold text-gray-900">@address.Title</p>
+                        <p class="mt-1 text-sm text-gray-600">@address.FullAddress</p>
+                        <p class="mt-1 text-xs text-gray-500">@address.Neighbourhood, @address.State / @address.City</p>
+                        <p class="mt-1 text-xs text-gray-500">@address.Name @address.Surname • @address.PhoneNumber</p>
+                    </div>
+                    @if (address.IsDefault)
+                    {
+                        <span class="rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700">Varsayılan</span>
+                    }
+                </div>
+
+                <div class="mt-4 flex flex-wrap gap-2 text-xs">
+                    <button type="button"
+                            class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 transition hover:border-amber-300 hover:text-amber-600"
+                            @@click="$store.address.openEdit($el.dataset)"
+                            data-id="@address.Id"
+                            data-title="@address.Title"
+                            data-name="@address.Name"
+                            data-surname="@address.Surname"
+                            data-phone-number="@address.PhoneNumber"
+                            data-full-address="@address.FullAddress"
+                            data-city="@address.City"
+                            data-state="@address.State"
+                            data-country="@address.Country"
+                            data-neighbourhood="@address.Neighbourhood"
+                            data-is-default="@address.IsDefault.ToString().ToLowerInvariant()">
+                        Düzenle
+                    </button>
+
+                    <button type="button"
+                            class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 transition hover:border-amber-300 hover:text-amber-600 disabled:opacity-50"
+                            hx-post="@Url.Action("SetDefault", "Address")"
+                            hx-target="#@Model.ContainerId"
+                            hx-swap="outerHTML"
+                            hx-vals='{"id": @address.Id}'
+                            @(address.IsDefault ? "disabled" : null)>
+                        Varsayılan Yap
+                    </button>
+                </div>
+            </div>
+        }
+    }
+</div>

--- a/ECommerceBatteryShop/Views/Address/_AddressModal.cshtml
+++ b/ECommerceBatteryShop/Views/Address/_AddressModal.cshtml
@@ -1,0 +1,169 @@
+@model string
+
+<div x-cloak x-data>
+    <div x-show="$store.address.open" x-transition.opacity
+         class="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/40"
+         role="dialog" aria-modal="true"
+         @@keydown.window.escape="$store.address.close()">
+        <div class="w-full max-w-lg rounded-md bg-white shadow-xl ring-1 ring-black/10"
+             @@click.outside="$store.address.close()">
+            <div class="flex items-center justify-between p-4 border-b border-slate-300">
+                <h3 class="text-base font-semibold text-slate-600" x-text="$store.address.mode === 'create' ? 'Adres Ekle' : 'Adresi Düzenle'"></h3>
+                <button class="p-2 rounded text-slate-500 hover:bg-slate-100" @@click="$store.address.close()">✕</button>
+            </div>
+
+            <form class="p-4 space-y-4"
+                  x-bind:hx-post="$store.address.formAction"
+                  hx-target="#@Model"
+                  hx-swap="outerHTML"
+                  x-on:htmx:afterOnLoad.window="$store.address.close()">
+
+                <input type="hidden" name="Id" x-model="$store.address.form.id" />
+                <input type="hidden" name="Country" x-model="$store.address.form.country" />
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div class="md:col-span-2">
+                        <label class="block text-sm font-medium text-slate-700">Adres Adı *</label>
+                        <input name="Title" required x-model="$store.address.form.title"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                    </div>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium text-slate-700">Ad *</label>
+                        <input name="Name" required x-model="$store.address.form.name"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-slate-700">Soyad *</label>
+                        <input name="Surname" required x-model="$store.address.form.surname"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                    </div>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium text-slate-700">Telefon *</label>
+                        <input name="PhoneNumber" required x-model="$store.address.form.phoneNumber" placeholder="+90 5XX XXX XX XX"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-slate-700">İl *</label>
+                        <input name="City" required x-model="$store.address.form.city"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                    </div>
+                </div>
+
+                <div>
+                    <label class="block text-sm font-medium text-slate-700">Adres *</label>
+                    <textarea name="FullAddress" rows="3" x-model="$store.address.form.fullAddress"
+                              placeholder="Adresinizi mahalle, sokak, cadde, bina ve daire numarası ile beraber tam girdiğinizden emin olun."
+                              required
+                              class="mt-1 w-full rounded-lg p-2 border border-slate-300 focus:ring-amber-300 focus:border-amber-300"></textarea>
+                </div>
+
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div>
+                        <label class="block text-sm font-medium text-slate-700">İlçe *</label>
+                        <input name="State" required x-model="$store.address.form.state"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-slate-700">Mahalle *</label>
+                        <input name="Neighbourhood" required x-model="$store.address.form.neighbourhood"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                    </div>
+                </div>
+
+                <div class="flex items-center justify-between gap-2 pt-2">
+                    <label class="inline-flex items-center gap-2 text-xs text-slate-500">
+                        <input type="checkbox" name="IsDefault" x-model="$store.address.form.isDefault"
+                               class="rounded border-slate-300">
+                        Varsayılan adres olarak işaretle
+                    </label>
+
+                    <div class="flex items-center gap-2">
+                        <button type="button"
+                                @@click="$store.address.close()"
+                                class="rounded-lg border border-slate-400 px-4 py-2 text-sm text-slate-600 hover:bg-slate-100">
+                            Vazgeç
+                        </button>
+                        <button type="submit"
+                                class="rounded-lg bg-amber-300 px-4 py-2 text-sm font-semibold border border-amber-300 text-gray-900 hover:bg-amber-400">
+                            Kaydet
+                        </button>
+                    </div>
+                </div>
+            </form>
+
+        </div>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('alpine:init', () => {
+        if (!Alpine.store('address')) {
+            Alpine.store('address', {
+                open: false,
+                mode: 'create',
+                form: {
+                    id: 0,
+                    title: '',
+                    name: '',
+                    surname: '',
+                    phoneNumber: '',
+                    fullAddress: '',
+                    city: '',
+                    state: '',
+                    country: '',
+                    neighbourhood: '',
+                    isDefault: false
+                },
+                get formAction() {
+                    return '/Address/Upsert';
+                },
+                resetForm() {
+                    this.form = {
+                        id: 0,
+                        title: '',
+                        name: '',
+                        surname: '',
+                        phoneNumber: '',
+                        fullAddress: '',
+                        city: '',
+                        state: '',
+                        country: '',
+                        neighbourhood: '',
+                        isDefault: false
+                    };
+                },
+                openNew() {
+                    this.mode = 'create';
+                    this.resetForm();
+                    this.open = true;
+                },
+                openEdit(dataset) {
+                    this.mode = 'edit';
+                    this.form = {
+                        id: Number(dataset.id ?? 0),
+                        title: dataset.title ?? '',
+                        name: dataset.name ?? '',
+                        surname: dataset.surname ?? '',
+                        phoneNumber: dataset.phoneNumber ?? '',
+                        fullAddress: dataset.fullAddress ?? '',
+                        city: dataset.city ?? '',
+                        state: dataset.state ?? '',
+                        country: dataset.country ?? '',
+                        neighbourhood: dataset.neighbourhood ?? '',
+                        isDefault: dataset.isDefault === 'true'
+                    };
+                    this.open = true;
+                },
+                close() {
+                    this.open = false;
+                }
+            });
+        }
+    });
+</script>

--- a/ECommerceBatteryShop/Views/Cart/Checkout.cshtml
+++ b/ECommerceBatteryShop/Views/Cart/Checkout.cshtml
@@ -1,10 +1,10 @@
+@model ECommerceBatteryShop.Models.CheckoutViewModel
 @{
     ViewBag.Title = "Checkout";
-}
-@model decimal
-@{
-    decimal subTotal = Model;
-    decimal tax = subTotal * 0.2m;
+    decimal subTotal = Model.Subtotal;
+    decimal tax = Model.Tax;
+    decimal shipping = Model.Shipping;
+    decimal total = Model.Total;
 }
 <main x-data class="bg-white min-h-screen pt-10 pb-24">
     <div class="mx-auto max-w-5xl px-4">
@@ -36,24 +36,7 @@
                         </button>
                     </div>
 
-                    <div id="address-list" class="mt-6 grid gap-4 md:grid-cols-2">
-                        <div class="rounded-xl border border-gray-100 p-4">
-                            <p class="text-sm font-semibold text-gray-900">Ev Adresi</p>
-                            <p class="mt-1 text-sm text-gray-600">Ataköy Mah./ İstanbul</p>
-                            <div class="mt-4 flex gap-2 text-xs">
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 hover:border-amber-300 hover:text-amber-600">Düzenle</button>
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 hover:border-amber-300 hover:text-amber-600">Varsayılan Yap</button>
-                            </div>
-                        </div>
-                        <div class="rounded-xl border border-gray-100 p-4">
-                            <p class="text-sm font-semibold text-gray-900">İş Adresi</p>
-                            <p class="mt-1 text-sm text-gray-600">Teknopark İstanbul</p>
-                            <div class="mt-4 flex gap-2 text-xs">
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 hover:border-amber-300 hover:text-amber-600">Düzenle</button>
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 hover:border-amber-300 hover:text-amber-600">Varsayılan Yap</button>
-                            </div>
-                        </div>
-                    </div>
+                    @await Html.PartialAsync("~/Views/Address/_AddressList.cshtml", Model.AddressList)
                 </section>
 
                 <!-- Ödeme Yöntemi -->
@@ -135,11 +118,11 @@
                     <h3 class="text-base font-semibold text-slate-900 mb-4">Sipariş Özeti</h3>
                     <dl class="space-y-2 text-sm">
                         <div class="flex justify-between"><dt class="text-slate-600">Ara Toplam</dt><dd class="text-slate-900 font-medium">₺@subTotal</dd></div>
-                        <div class="flex justify-between"><dt class="text-slate-600">Kargo</dt><dd class="text-slate-900 font-medium">₺150</dd></div>
+                        <div class="flex justify-between"><dt class="text-slate-600">Kargo</dt><dd class="text-slate-900 font-medium">₺@shipping</dd></div>
                         <div class="flex justify-between"><dt class="text-slate-600">KDV (dahil)</dt><dd class="text-slate-900 font-medium">₺@tax</dd></div>
                         <div class="h-px bg-slate-200 my-2"></div>
                         <div class="flex justify-between text-base">
-                            <dt class="text-slate-900 font-semibold">Genel Toplam</dt><dd class="text-slate-900 font-semibold">₺@(subTotal+150)</dd>
+                            <dt class="text-slate-900 font-semibold">Genel Toplam</dt><dd class="text-slate-900 font-semibold">₺@total</dd>
                         </div>
                     </dl>
                     <p class="text-xs text-slate-500 mt-4">Adres ve ödeme bilgilerinizi doğrulamadan sipariş oluşturulmaz.</p>
@@ -154,103 +137,8 @@
     [x-cloak] {
         display: none !important
     }</style>
-<div x-cloak x-data>
-    <div x-show="$store.address.open" x-transition.opacity
-         class="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/40"
-         role="dialog" aria-modal="true"
-         @@keydown.window.escape="$store.address.close()">
-        <div class="w-full max-w-lg rounded-md bg-white shadow-xl ring-1 ring-black/10"
-             @@click.outside="$store.address.close()">
-            <div class="flex items-center justify-between p-4 border-b border-slate-300">
-                <h3 class="text-base font-semibold text-slate-600">Adres Ekle</h3>
-                <button class="p-2 rounded text-slate-500 hover:bg-slate-100" @@click="$store.address.close()">✕</button>
-            </div>
-
-            <form class="p-4 space-y-4"
-                  hx-post="/Address/Upsert"
-                  hx-target="#address-list"
-                  hx-swap="outerHTML"
-                  x-on:htmx:afterOnLoad.window="$store.address.close()">
-
-                <div>
-                    <label class="block text-sm font-medium text-slate-700">Adres Adı</label>
-                    <input name="AddressName" required
-                           class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
-                </div>
-
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                        <label class="block text-sm font-medium text-slate-700">Ad *</label>
-                        <input name="Name" required
-                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
-                    </div>
-                    <div>
-                        <label class="block text-sm font-medium text-slate-700">Soyad *</label>
-                        <input name="Surname" required
-                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
-                    </div>
-                </div>
-
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                        <label class="block text-sm font-medium text-slate-700">Telefon *</label>
-                        <input name="Phone" required placeholder="+90 5XX XXX XX XX"
-                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
-                    </div>
-                    <div>
-                        <label class="block text-sm font-medium text-slate-700">İl *</label>
-                        <input name="City" required
-                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
-                    </div>
-                </div>
-
-                <div>
-                    <label class="block text-sm font-medium text-slate-700">Adres *</label>
-                    <textarea name="Line" rows="3"
-                              placeholder="Adresinizi mahalle, sokak, cadde, bina ve daire numarası ile beraber tam girdiğinize emin olun."
-                              required
-                              class="mt-1 w-full rounded-lg p-2 border border-slate-300 focus:ring-amber-300 focus:border-amber-300"></textarea>
-                </div>
-
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <div>
-                        <label class="block text-sm font-medium text-slate-700">İlçe *</label>
-                        <input name="District" required
-                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
-                    </div>
-                    <div>
-                        <label class="block text-sm font-medium text-slate-700">Mahalle *</label>
-                        <input name="Neighborhood" required
-                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
-                    </div>
-                </div>
-
-                <div class="flex items-center justify-end gap-2 pt-2">
-                    <button type="button"
-                            @@click="$store.address.close()"
-                            class="rounded-lg border border-slate-400 px-4 py-2 text-sm text-slate-600 hover:bg-slate-100">
-                        Vazgeç
-                    </button>
-                    <button type="submit"
-                            class="rounded-lg bg-amber-300 px-4 py-2 text-sm font-semibold border border-amber-300 text-gray-900 hover:bg-amber-400">
-                        Kaydet
-                    </button>
-                </div>
-            </form>
-
-        </div>
-    </div>
-</div>
-
+@await Html.PartialAsync("~/Views/Address/_AddressModal.cshtml", Model.AddressList.ContainerId)
 <script>
-    document.addEventListener('alpine:init', () => {
-      Alpine.store('address', {
-        open: false,
-        openNew(){ this.open = true },
-        close(){ this.open = false }
-      });
-    });
-
     // IBAN copy
     (function () {
       const btn = document.getElementById('copyIban');


### PR DESCRIPTION
## Summary
- add secure address upsert, default selection, and list endpoints that render a shared address list partial
- replace hard-coded address cards in checkout and profile views with dynamic data supplied via new view models and reusable modal UI
- extend the checkout flow with a dedicated view model carrying totals and customer addresses for display and interaction

## Testing
- dotnet build *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d62ae0f1e0832099e9364eb1fb8e33