### PR TITLE
Implement address management for checkout and profile

### DIFF
--- a/ECommerceBatteryShop.DataAccess/Abstract/IAddressRepository.cs
+++ b/ECommerceBatteryShop.DataAccess/Abstract/IAddressRepository.cs
@@ -1,0 +1,12 @@
+using ECommerceBatteryShop.Domain.Entities;
+
+namespace ECommerceBatteryShop.DataAccess.Abstract;
+
+public interface IAddressRepository
+{
+    Task<IReadOnlyList<Address>> GetByUserAsync(int userId, CancellationToken ct = default);
+    Task<Address?> GetByIdAsync(int userId, int addressId, CancellationToken ct = default);
+    Task<Address> AddAsync(Address address, CancellationToken ct = default);
+    Task<Address?> UpdateAsync(Address address, CancellationToken ct = default);
+    Task<bool> SetDefaultAsync(int userId, int addressId, CancellationToken ct = default);
+}

--- a/ECommerceBatteryShop.DataAccess/Concrete/AddressRepository.cs
+++ b/ECommerceBatteryShop.DataAccess/Concrete/AddressRepository.cs
@@ -1,0 +1,97 @@
+using ECommerceBatteryShop.DataAccess.Abstract;
+using ECommerceBatteryShop.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace ECommerceBatteryShop.DataAccess.Concrete;
+
+public class AddressRepository : IAddressRepository
+{
+    private readonly BatteryShopContext _ctx;
+    private readonly ILogger<AddressRepository> _logger;
+
+    public AddressRepository(BatteryShopContext ctx, ILogger<AddressRepository> logger)
+    {
+        _ctx = ctx;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<Address>> GetByUserAsync(int userId, CancellationToken ct = default)
+    {
+        return await _ctx.Addresses
+            .AsNoTracking()
+            .Where(a => a.UserId == userId)
+            .OrderByDescending(a => a.IsDefault)
+            .ThenBy(a => a.Title)
+            .ToListAsync(ct);
+    }
+
+    public async Task<Address?> GetByIdAsync(int userId, int addressId, CancellationToken ct = default)
+    {
+        return await _ctx.Addresses
+            .FirstOrDefaultAsync(a => a.Id == addressId && a.UserId == userId, ct);
+    }
+
+    public async Task<Address> AddAsync(Address address, CancellationToken ct = default)
+    {
+        var hasAddress = await _ctx.Addresses.AnyAsync(a => a.UserId == address.UserId, ct);
+        if (!hasAddress)
+        {
+            address.IsDefault = true;
+        }
+
+        _ctx.Addresses.Add(address);
+        await _ctx.SaveChangesAsync(ct);
+        _logger.LogInformation("Address {AddressId} added for user {UserId}", address.Id, address.UserId);
+        return address;
+    }
+
+    public async Task<Address?> UpdateAsync(Address address, CancellationToken ct = default)
+    {
+        var existing = await _ctx.Addresses.FirstOrDefaultAsync(a => a.Id == address.Id && a.UserId == address.UserId, ct);
+        if (existing is null)
+        {
+            _logger.LogWarning("Attempted to update address {AddressId} for user {UserId}, but it was not found", address.Id, address.UserId);
+            return null;
+        }
+
+        existing.Title = address.Title;
+        existing.Name = address.Name;
+        existing.Surname = address.Surname;
+        existing.PhoneNumber = address.PhoneNumber;
+        existing.FullAddress = address.FullAddress;
+        existing.City = address.City;
+        existing.State = address.State;
+        existing.Country = address.Country;
+        existing.Neighbourhood = address.Neighbourhood;
+        existing.IsDefault = address.IsDefault;
+
+        await _ctx.SaveChangesAsync(ct);
+        _logger.LogInformation("Address {AddressId} updated for user {UserId}", address.Id, address.UserId);
+        return existing;
+    }
+
+    public async Task<bool> SetDefaultAsync(int userId, int addressId, CancellationToken ct = default)
+    {
+        await using var transaction = await _ctx.Database.BeginTransactionAsync(ct);
+
+        var target = await _ctx.Addresses.FirstOrDefaultAsync(a => a.Id == addressId && a.UserId == userId, ct);
+        if (target is null)
+        {
+            _logger.LogWarning("Attempted to set default address {AddressId} for user {UserId}, but it was not found", addressId, userId);
+            await transaction.RollbackAsync(ct);
+            return false;
+        }
+
+        await _ctx.Addresses
+            .Where(a => a.UserId == userId && a.Id != addressId && a.IsDefault)
+            .ExecuteUpdateAsync(s => s.SetProperty(a => a.IsDefault, false), ct);
+
+        target.IsDefault = true;
+        await _ctx.SaveChangesAsync(ct);
+        await transaction.CommitAsync(ct);
+
+        _logger.LogInformation("Address {AddressId} set as default for user {UserId}", addressId, userId);
+        return true;
+    }
+}

--- a/ECommerceBatteryShop/Controllers/AddressController.cs
+++ b/ECommerceBatteryShop/Controllers/AddressController.cs
@@ -1,12 +1,173 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+using ECommerceBatteryShop.DataAccess.Abstract;
+using ECommerceBatteryShop.Domain.Entities;
+using ECommerceBatteryShop.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 
-namespace ECommerceBatteryShop.Controllers
+namespace ECommerceBatteryShop.Controllers;
+
+[Authorize]
+public class AddressController : Controller
 {
-    public class AddressController : Controller
+    private readonly IAddressRepository _addressRepository;
+    private readonly ILogger<AddressController> _logger;
+
+    public AddressController(IAddressRepository addressRepository, ILogger<AddressController> logger)
     {
-        public IActionResult Index()
+        _addressRepository = addressRepository;
+        _logger = logger;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> List(CancellationToken ct)
+    {
+        var userId = GetUserId();
+        if (!userId.HasValue)
         {
-            return View();
+            return Unauthorized();
         }
+
+        var addresses = await _addressRepository.GetByUserAsync(userId.Value, ct);
+        return PartialView("_AddressListPartial", addresses.Select(MapToViewModel).ToList());
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> Upsert(AddressInputModel model, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        if (!userId.HasValue)
+        {
+            return Unauthorized();
+        }
+
+        if (!ModelState.IsValid)
+        {
+            Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
+            var addresses = await _addressRepository.GetByUserAsync(userId.Value, ct);
+            return PartialView("_AddressListPartial", addresses.Select(MapToViewModel).ToList());
+        }
+
+        var shouldSetDefault = model.IsDefault;
+        Address? saved;
+
+        if (model.Id.HasValue)
+        {
+            var updated = await _addressRepository.UpdateAsync(new Address
+            {
+                Id = model.Id.Value,
+                UserId = userId.Value,
+                Title = model.Title.Trim(),
+                Name = model.Name.Trim(),
+                Surname = model.Surname.Trim(),
+                PhoneNumber = model.PhoneNumber.Trim(),
+                FullAddress = model.FullAddress.Trim(),
+                City = model.City.Trim(),
+                State = model.State.Trim(),
+                Country = model.Country?.Trim() ?? string.Empty,
+                Neighbourhood = model.Neighbourhood.Trim(),
+                IsDefault = model.IsDefault
+            }, ct);
+
+            if (updated is null)
+            {
+                return NotFound();
+            }
+
+            saved = updated;
+        }
+        else
+        {
+            var created = await _addressRepository.AddAsync(new Address
+            {
+                UserId = userId.Value,
+                Title = model.Title.Trim(),
+                Name = model.Name.Trim(),
+                Surname = model.Surname.Trim(),
+                PhoneNumber = model.PhoneNumber.Trim(),
+                FullAddress = model.FullAddress.Trim(),
+                City = model.City.Trim(),
+                State = model.State.Trim(),
+                Country = model.Country?.Trim() ?? string.Empty,
+                Neighbourhood = model.Neighbourhood.Trim(),
+                IsDefault = model.IsDefault
+            }, ct);
+
+            saved = created;
+            shouldSetDefault = created.IsDefault || shouldSetDefault;
+        }
+
+        if (saved is not null && shouldSetDefault)
+        {
+            await _addressRepository.SetDefaultAsync(userId.Value, saved.Id, ct);
+        }
+
+        var refreshed = await _addressRepository.GetByUserAsync(userId.Value, ct);
+        if (!refreshed.Any(a => a.IsDefault) && refreshed.Count > 0)
+        {
+            var fallback = refreshed.First();
+            await _addressRepository.SetDefaultAsync(userId.Value, fallback.Id, ct);
+            refreshed = await _addressRepository.GetByUserAsync(userId.Value, ct);
+        }
+
+        return PartialView("_AddressListPartial", refreshed.Select(MapToViewModel).ToList());
+    }
+
+    [HttpPost]
+    [ValidateAntiForgeryToken]
+    public async Task<IActionResult> SetDefault(int id, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        if (!userId.HasValue)
+        {
+            return Unauthorized();
+        }
+
+        var result = await _addressRepository.SetDefaultAsync(userId.Value, id, ct);
+        if (!result)
+        {
+            return NotFound();
+        }
+
+        var addresses = await _addressRepository.GetByUserAsync(userId.Value, ct);
+        return PartialView("_AddressListPartial", addresses.Select(MapToViewModel).ToList());
+    }
+
+    private int? GetUserId()
+    {
+        var claim = User.FindFirst("sub") ?? User.FindFirst(ClaimTypes.NameIdentifier);
+        if (claim is null)
+        {
+            return null;
+        }
+
+        if (int.TryParse(claim.Value, out var userId))
+        {
+            return userId;
+        }
+
+        _logger.LogWarning("Could not parse user id claim value {Claim}", claim.Value);
+        return null;
+    }
+
+    private static AddressViewModel MapToViewModel(Address address)
+    {
+        return new AddressViewModel
+        {
+            Id = address.Id,
+            UserId = address.UserId,
+            Title = address.Title,
+            Name = address.Name,
+            Surname = address.Surname,
+            PhoneNumber = address.PhoneNumber,
+            FullAddress = address.FullAddress,
+            City = address.City,
+            State = address.State,
+            Country = address.Country,
+            Neighbourhood = address.Neighbourhood,
+            IsDefault = address.IsDefault
+        };
     }
 }

--- a/ECommerceBatteryShop/Models/AddressInputModel.cs
+++ b/ECommerceBatteryShop/Models/AddressInputModel.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ECommerceBatteryShop.Models;
+
+public class AddressInputModel
+{
+    public int? Id { get; set; }
+
+    [Required, StringLength(128)]
+    public string Title { get; set; } = string.Empty;
+
+    [Required, StringLength(128)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required, StringLength(128)]
+    public string Surname { get; set; } = string.Empty;
+
+    [Required, StringLength(32)]
+    [Phone]
+    public string PhoneNumber { get; set; } = string.Empty;
+
+    [Required, StringLength(512)]
+    public string FullAddress { get; set; } = string.Empty;
+
+    [Required, StringLength(128)]
+    public string City { get; set; } = string.Empty;
+
+    [Required, StringLength(128)]
+    public string State { get; set; } = string.Empty;
+
+    [StringLength(128)]
+    public string Country { get; set; } = "Türkiye";
+
+    [Required, StringLength(256)]
+    public string Neighbourhood { get; set; } = string.Empty;
+
+    public bool IsDefault { get; set; }
+}

--- a/ECommerceBatteryShop/Models/AddressViewModel.cs
+++ b/ECommerceBatteryShop/Models/AddressViewModel.cs
@@ -13,6 +13,8 @@ namespace ECommerceBatteryShop.Models
         public string FullAddress { get; set; } = string.Empty;
         public string City { get; set; } = string.Empty;
         public string State { get; set; } = string.Empty;
-        public string NeightBourhood { get; set; } = string.Empty;
+        public string Country { get; set; } = string.Empty;
+        public string Neighbourhood { get; set; } = string.Empty;
+        public bool IsDefault { get; set; }
     }
 }

--- a/ECommerceBatteryShop/Models/CheckoutPageViewModel.cs
+++ b/ECommerceBatteryShop/Models/CheckoutPageViewModel.cs
@@ -1,0 +1,8 @@
+namespace ECommerceBatteryShop.Models;
+
+public class CheckoutPageViewModel
+{
+    public decimal SubTotal { get; set; }
+    public decimal ShippingCost { get; set; } = 150m;
+    public IReadOnlyList<AddressViewModel> Addresses { get; set; } = Array.Empty<AddressViewModel>();
+}

--- a/ECommerceBatteryShop/Models/ProfileViewModel.cs
+++ b/ECommerceBatteryShop/Models/ProfileViewModel.cs
@@ -1,0 +1,6 @@
+namespace ECommerceBatteryShop.Models;
+
+public class ProfileViewModel
+{
+    public IReadOnlyList<AddressViewModel> Addresses { get; set; } = Array.Empty<AddressViewModel>();
+}

--- a/ECommerceBatteryShop/Program.cs
+++ b/ECommerceBatteryShop/Program.cs
@@ -24,6 +24,7 @@ builder.Services.AddDbContext<BatteryShopContext>(opt =>
   builder.Services.AddScoped<IAccountRepository, AccountRepository>();
   builder.Services.AddScoped<ICartRepository, CartRepository>();
   builder.Services.AddScoped<ICategoryRepository, CategoryRepository>();
+  builder.Services.AddScoped<IAddressRepository, AddressRepository>();
   builder.Services.AddScoped<IUserService, UserService>();
   builder.Services.AddScoped<ICartService, CartService>();
   builder.Services.AddScoped<IFavoritesService, FavoritesService>();

--- a/ECommerceBatteryShop/Views/Account/Profile.cshtml
+++ b/ECommerceBatteryShop/Views/Account/Profile.cshtml
@@ -1,3 +1,4 @@
+@model ECommerceBatteryShop.Models.ProfileViewModel
 @{
     Layout = "_Layout";
     ViewData["Title"] = "Profil";
@@ -238,24 +239,7 @@
                         </button>
                     </div>
 
-                    <div class="mt-6 grid gap-4 md:grid-cols-2">
-                        <div class="rounded-xl border border-gray-100 p-4">
-                            <p class="text-sm font-semibold text-gray-900">Ev Adresi</p>
-                            <p class="mt-1 text-sm text-gray-600">Ataköy Mah./ İstanbul</p>
-                            <div class="mt-4 flex gap-2 text-xs">
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 transition hover:border-amber-300 hover:text-amber-600">Düzenle</button>
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 transition hover:border-amber-300 hover:text-amber-600">Varsayılan Yap</button>
-                            </div>
-                        </div>
-                        <div class="rounded-xl border border-gray-100 p-4">
-                            <p class="text-sm font-semibold text-gray-900">İş Adresi</p>
-                            <p class="mt-1 text-sm text-gray-600">Teknopark İstanbul</p>
-                            <div class="mt-4 flex gap-2 text-xs">
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 transition hover:border-amber-300 hover:text-amber-600">Düzenle</button>
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 transition hover:border-amber-300 hover:text-amber-600">Varsayılan Yap</button>
-                            </div>
-                        </div>
-                    </div>
+                    @await Html.PartialAsync("_AddressListPartial", Model.Addresses)
                 </section>
 
                 <section id="support" class="rounded-2xl bg-gradient-to-br from-gray-900 via-gray-800 to-black p-6 text-white shadow-sm">

--- a/ECommerceBatteryShop/Views/Cart/Checkout.cshtml
+++ b/ECommerceBatteryShop/Views/Cart/Checkout.cshtml
@@ -1,10 +1,11 @@
 @{
     ViewBag.Title = "Checkout";
 }
-@model decimal
+@model ECommerceBatteryShop.Models.CheckoutPageViewModel
 @{
-    decimal subTotal = Model;
+    decimal subTotal = Model.SubTotal;
     decimal tax = subTotal * 0.2m;
+    decimal shipping = Model.ShippingCost;
 }
 <main x-data class="bg-white min-h-screen pt-10 pb-24">
     <div class="mx-auto max-w-5xl px-4">
@@ -36,24 +37,7 @@
                         </button>
                     </div>
 
-                    <div id="address-list" class="mt-6 grid gap-4 md:grid-cols-2">
-                        <div class="rounded-xl border border-gray-100 p-4">
-                            <p class="text-sm font-semibold text-gray-900">Ev Adresi</p>
-                            <p class="mt-1 text-sm text-gray-600">Ataköy Mah./ İstanbul</p>
-                            <div class="mt-4 flex gap-2 text-xs">
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 hover:border-amber-300 hover:text-amber-600">Düzenle</button>
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 hover:border-amber-300 hover:text-amber-600">Varsayılan Yap</button>
-                            </div>
-                        </div>
-                        <div class="rounded-xl border border-gray-100 p-4">
-                            <p class="text-sm font-semibold text-gray-900">İş Adresi</p>
-                            <p class="mt-1 text-sm text-gray-600">Teknopark İstanbul</p>
-                            <div class="mt-4 flex gap-2 text-xs">
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 hover:border-amber-300 hover:text-amber-600">Düzenle</button>
-                                <button type="button" class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 hover:border-amber-300 hover:text-amber-600">Varsayılan Yap</button>
-                            </div>
-                        </div>
-                    </div>
+                    @await Html.PartialAsync("_AddressListPartial", Model.Addresses)
                 </section>
 
                 <!-- Ödeme Yöntemi -->
@@ -139,11 +123,11 @@
                     <h3 class="text-base font-semibold text-slate-900 mb-4">Sipariş Özeti</h3>
                     <dl class="space-y-2 text-sm">
                         <div class="flex justify-between"><dt class="text-slate-600">Ara Toplam</dt><dd class="text-slate-900 font-medium">₺@subTotal</dd></div>
-                        <div class="flex justify-between"><dt class="text-slate-600">Kargo</dt><dd class="text-slate-900 font-medium">₺150</dd></div>
+                        <div class="flex justify-between"><dt class="text-slate-600">Kargo</dt><dd class="text-slate-900 font-medium">₺@shipping</dd></div>
                         <div class="flex justify-between"><dt class="text-slate-600">KDV (dahil)</dt><dd class="text-slate-900 font-medium">₺@tax</dd></div>
                         <div class="h-px bg-slate-200 my-2"></div>
                         <div class="flex justify-between text-base">
-                            <dt class="text-slate-900 font-semibold">Genel Toplam</dt><dd class="text-slate-900 font-semibold">₺@(subTotal+150)</dd>
+                            <dt class="text-slate-900 font-semibold">Genel Toplam</dt><dd class="text-slate-900 font-semibold">₺@(subTotal + shipping)</dd>
                         </div>
                     </dl>
                     <p class="text-xs text-slate-500 mt-4">Adres ve ödeme bilgilerinizi doğrulamadan sipariş oluşturulmaz.</p>

--- a/ECommerceBatteryShop/Views/Shared/_AddressListPartial.cshtml
+++ b/ECommerceBatteryShop/Views/Shared/_AddressListPartial.cshtml
@@ -1,0 +1,82 @@
+@using System.Text.Json
+@model IReadOnlyList<ECommerceBatteryShop.Models.AddressViewModel>
+
+@{
+    var addresses = Model ?? Array.Empty<ECommerceBatteryShop.Models.AddressViewModel>();
+    var jsonOptions = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+}
+
+<div id="address-list" class="mt-6 grid gap-4 md:grid-cols-2">
+    @if (!addresses.Any())
+    {
+        <div class="rounded-xl border border-dashed border-slate-300 p-6 text-center text-sm text-slate-500">
+            Henüz kayıtlı adresiniz yok. Yeni bir adres eklemek için yukarıdaki butonu kullanın.
+        </div>
+    }
+    else
+    {
+        foreach (var address in addresses)
+        {
+            var payload = JsonSerializer.Serialize(new
+            {
+                id = address.Id,
+                title = address.Title,
+                name = address.Name,
+                surname = address.Surname,
+                phoneNumber = address.PhoneNumber,
+                fullAddress = address.FullAddress,
+                city = address.City,
+                state = address.State,
+                country = address.Country,
+                neighbourhood = address.Neighbourhood,
+                isDefault = address.IsDefault
+            }, jsonOptions);
+            var cardClasses = address.IsDefault
+                ? "rounded-xl border-2 border-amber-300 bg-amber-50 p-4"
+                : "rounded-xl border border-gray-100 p-4";
+            <article class="@cardClasses">
+                <div class="flex items-center justify-between gap-2">
+                    <p class="text-sm font-semibold text-gray-900">@address.Title</p>
+                    @if (address.IsDefault)
+                    {
+                        <span class="rounded-full bg-amber-200 px-3 py-1 text-xs font-semibold text-amber-700">Varsayılan</span>
+                    }
+                </div>
+                <p class="mt-2 text-sm text-gray-700 font-medium">@address.Name @address.Surname</p>
+                <p class="text-sm text-gray-500">@address.PhoneNumber</p>
+                <p class="mt-3 text-sm text-gray-600 whitespace-pre-line">@address.FullAddress</p>
+                <p class="text-xs text-gray-500 mt-2">@address.Neighbourhood, @address.State / @address.City</p>
+
+                <div class="mt-4 flex flex-wrap items-center gap-2 text-xs">
+                    <button type="button"
+                            class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 transition hover:border-amber-300 hover:text-amber-600"
+                            @@click="$store.address.edit(@Html.Raw(payload))">
+                        Düzenle
+                    </button>
+                    @if (!address.IsDefault)
+                    {
+                        <form method="post"
+                              hx-post="@Url.Action("SetDefault", "Address")"
+                              hx-target="#address-list"
+                              hx-swap="outerHTML"
+                              class="contents">
+                            @Html.AntiForgeryToken()
+                            <input type="hidden" name="id" value="@address.Id" />
+                            <button type="submit"
+                                    class="rounded-full border border-gray-200 px-3 py-1 text-gray-600 transition hover:border-amber-300 hover:text-amber-600">
+                                Varsayılan Yap
+                            </button>
+                        </form>
+                    }
+                    else
+                    {
+                        <button type="button" disabled
+                                class="rounded-full border border-amber-300 bg-amber-100 px-3 py-1 text-amber-600">
+                            Varsayılan
+                        </button>
+                    }
+                </div>
+            </article>
+        }
+    }
+</div>

--- a/ECommerceBatteryShop/Views/Shared/_AddressModalPartial.cshtml
+++ b/ECommerceBatteryShop/Views/Shared/_AddressModalPartial.cshtml
@@ -1,10 +1,10 @@
-﻿
 <!-- Address Modal -->
 <style>
     [x-cloak] {
-        display: none !important
-    }</style>
-<div x-cloak x-data>
+        display: none !important;
+    }
+</style>
+<div x-cloak>
     <div x-show="$store.address.open" x-transition.opacity
          class="fixed inset-0 z-[100] flex items-center justify-center p-4 bg-black/40"
          role="dialog" aria-modal="true"
@@ -12,71 +12,79 @@
         <div class="w-full max-w-lg rounded-md bg-white shadow-xl ring-1 ring-black/10"
              @@click.outside="$store.address.close()">
             <div class="flex items-center justify-between p-4 border-b border-slate-300">
-                <h3 class="text-base font-semibold text-slate-600">Adres Ekle</h3>
+                <h3 class="text-base font-semibold text-slate-600" x-text="$store.address.form.id ? 'Adres Düzenle' : 'Adres Ekle'"></h3>
                 <button class="p-2 rounded text-slate-500 hover:bg-slate-100" @@click="$store.address.close()">✕</button>
             </div>
             <form class="p-4 space-y-4"
-                  hx-post="/Address/Upsert"
+                  hx-post="@Url.Action("Upsert", "Address")"
                   hx-target="#address-list"
                   hx-swap="outerHTML"
-                  x-on:htmx:afterOnLoad.window="$store.address.close()">
+                  x-on:htmx:afterOnLoad.window="$store.address.close(); $store.address.reset()">
+                @Html.AntiForgeryToken()
+                <input type="hidden" name="Id" x-model="$store.address.form.id" />
+                <input type="hidden" name="Country" x-model="$store.address.form.country" />
 
                 <div>
-                    <label class="block text-sm font-medium text-slate-700">Adres Adı</label>
-                    <input name="AddressName" required
-                           class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                    <label class="block text-sm font-medium text-slate-700">Adres Başlığı *</label>
+                    <input name="Title" required x-model="$store.address.form.title"
+                           class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300" />
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label class="block text-sm font-medium text-slate-700">Ad *</label>
-                        <input name="Name" required
-                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                        <input name="Name" required x-model="$store.address.form.name"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300" />
                     </div>
                     <div>
                         <label class="block text-sm font-medium text-slate-700">Soyad *</label>
-                        <input name="Surname" required
-                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                        <input name="Surname" required x-model="$store.address.form.surname"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300" />
                     </div>
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label class="block text-sm font-medium text-slate-700">Telefon *</label>
-                        <input name="Phone" required placeholder="+90 5XX XXX XX XX"
-                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                        <input name="PhoneNumber" required placeholder="+90 5XX XXX XX XX" x-model="$store.address.form.phoneNumber"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300" />
                     </div>
                     <div>
                         <label class="block text-sm font-medium text-slate-700">İl *</label>
-                        <input name="City" required
-                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                        <input name="City" required x-model="$store.address.form.city"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300" />
                     </div>
                 </div>
 
                 <div>
                     <label class="block text-sm font-medium text-slate-700">Adres *</label>
-                    <textarea name="Line" rows="3"
-                              placeholder="Adresinizi mahalle, sokak, cadde, bina ve daire numarası ile beraber tam girdiğinize emin olun."
-                              required
+                    <textarea name="FullAddress" rows="3" required x-model="$store.address.form.fullAddress"
+                              placeholder="Adresinizi mahalle, sokak, cadde, bina ve daire numarası ile beraber tam girdiğinizden emin olun."
                               class="mt-1 w-full rounded-lg p-2 border border-slate-300 focus:ring-amber-300 focus:border-amber-300"></textarea>
                 </div>
 
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div>
                         <label class="block text-sm font-medium text-slate-700">İlçe *</label>
-                        <input name="District" required
-                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                        <input name="State" required x-model="$store.address.form.state"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300" />
                     </div>
                     <div>
                         <label class="block text-sm font-medium text-slate-700">Mahalle *</label>
-                        <input name="Neighborhood" required
-                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300">
+                        <input name="Neighbourhood" required x-model="$store.address.form.neighbourhood"
+                               class="mt-1 p-2 w-full rounded-lg border border-slate-300 focus:ring-amber-300 focus:border-amber-300" />
                     </div>
+                </div>
+
+                <div class="flex items-center gap-2">
+                    <input type="checkbox" name="IsDefault" x-model="$store.address.form.isDefault"
+                           class="rounded border-slate-300 text-amber-500 focus:ring-amber-300" />
+                    <span class="text-sm text-slate-600">Varsayılan adres yap</span>
                 </div>
 
                 <div class="flex items-center justify-end gap-2 pt-2">
                     <button type="button"
-                            @@click="$store.address.close()"
+                            @@click="$store.address.close(); $store.address.reset()"
                             class="rounded-lg border border-slate-400 px-4 py-2 text-sm text-slate-600 hover:bg-slate-100">
                         Vazgeç
                     </button>
@@ -86,18 +94,47 @@
                     </button>
                 </div>
             </form>
-
         </div>
     </div>
 </div>
-
 
 <script>
     document.addEventListener('alpine:init', () => {
       Alpine.store('address', {
         open: false,
-        openNew(){ this.open = true },
-        close(){ this.open = false }
+        form: defaultForm(),
+        openNew() {
+          this.reset();
+          this.open = true;
+        },
+        edit(payload) {
+          this.form = { ...defaultForm(), ...(payload || {}) };
+          this.form.id = payload?.id ?? null;
+          this.form.isDefault = Boolean(payload?.isDefault);
+          this.open = true;
+        },
+        close() {
+          this.open = false;
+        },
+        reset() {
+          this.form = defaultForm();
+        }
       });
+
+      function defaultForm() {
+        return {
+          id: null,
+          title: '',
+          name: '',
+          surname: '',
+          phoneNumber: '',
+          city: '',
+          state: '',
+          country: 'Türkiye',
+          neighbourhood: '',
+          fullAddress: '',
+          isDefault: false
+        };
+      }
     });
 </script>


### PR DESCRIPTION
## Summary
- add an address repository and controller actions for loading, saving, and defaulting user addresses
- introduce shared view models and partials so checkout and profile render the signed-in user's saved addresses
- enhance the address modal to support editing, default selection, and HTMX refreshes of the address list

## Testing
- `dotnet build` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7aa087ec083208cffc9f58517be90