### PR TITLE
Add admin product editing capabilities

### DIFF
--- a/ECommerceBatteryShop/Models/AdminProductEntryViewModel.cs
+++ b/ECommerceBatteryShop/Models/AdminProductEntryViewModel.cs
@@ -1,13 +1,19 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Http;
 
 namespace ECommerceBatteryShop.Models;
 
-public class AdminProductEntryViewModel
+public class AdminProductEntryViewModel : IValidatableObject
 {
+    [Display(Name = "Ürün ID")]
+    public int? ProductId { get; set; }
+
     [Display(Name = "Ürün Görseli")]
-    [Required(ErrorMessage = "Lütfen bir ürün görseli yükleyin.")]
     public IFormFile? Image { get; set; }
+
+    [Display(Name = "Mevcut Görsel")]
+    public string? ExistingImageUrl { get; set; }
 
     [Required(ErrorMessage = "Ürün adı zorunludur."), StringLength(120, ErrorMessage = "Ürün adı 120 karakterden uzun olamaz.")]
     [Display(Name = "Ürün Adı")]
@@ -20,4 +26,30 @@ public class AdminProductEntryViewModel
     [Required(ErrorMessage = "Açıklama zorunludur."), StringLength(1000, ErrorMessage = "Açıklama 1000 karakterden uzun olamaz.")]
     [Display(Name = "Ürün Açıklaması")]
     public string Description { get; set; } = string.Empty;
+
+    [Display(Name = "Ürün Ara")]
+    public string? SearchTerm { get; set; }
+
+    public IList<AdminProductSelectionItemViewModel> SearchResults { get; set; } = new List<AdminProductSelectionItemViewModel>();
+
+    public bool IsEditing => ProductId.HasValue;
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        if (!ProductId.HasValue && Image is null)
+        {
+            yield return new ValidationResult("Yeni ürün oluşturmak için lütfen bir görsel yükleyin.", new[] { nameof(Image) });
+        }
+    }
+}
+
+public class AdminProductSelectionItemViewModel
+{
+    public int Id { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+
+    public decimal Price { get; set; }
+
+    public string? ImageUrl { get; set; }
 }

--- a/ECommerceBatteryShop/Views/Admin/Index.cshtml
+++ b/ECommerceBatteryShop/Views/Admin/Index.cshtml
@@ -3,41 +3,100 @@
     ViewData["Title"] = "Ürün Girişi";
     Layout = "_AdminLayout";
 }
+@{
+    var existingImagePath = string.IsNullOrWhiteSpace(Model.ExistingImageUrl)
+        ? Url.Content("~/img/placeholder-image.svg")
+        : Url.Content($"~/img/{Model.ExistingImageUrl}");
+}
 <main class="mx-auto max-w-7xl px-6 py-10">
     <div class="grid gap-8 lg:grid-cols-[320px_minmax(0,1fr)]">
-<aside class="space-y-6">
-    <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/40">
-        <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Hızlı Erişim</h2>
-        <nav class="mt-4 space-y-2 text-sm font-medium text-slate-700">
-            <a class="flex items-center justify-between rounded-xl bg-slate-900 px-4 py-3 text-white shadow-lg shadow-slate-900/20" href="#urun-girisi">
-                <span>Yeni Ürün Girişi</span>
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-4 w-4">
-                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M12 5l7 7-7 7" />
-                </svg>
-            </a>
-            <p class="rounded-xl px-4 py-3 text-slate-500">
-                Ürün görselleri, stok adetleri ve SEO ayarları giriş sırasında yönetilebilir.
-            </p>
-        </nav>
-    </div>
-    <div class="rounded-3xl border border-amber-200 bg-amber-50 p-6 shadow-inner">
-        <h3 class="text-sm font-semibold uppercase tracking-wide text-amber-700">İpucu</h3>
-        <p class="mt-3 text-sm leading-6 text-amber-900">
-            Ürün görseli yüksek çözünürlüklü olmalı (en az 1200px) ve sade bir arka plan içermelidir. Fiyatı girerken vergiler dahil değeri tercih edin.
-        </p>
-    </div>
-</aside>
+        <aside class="space-y-6">
+            <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/40">
+                <h2 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Hızlı Erişim</h2>
+                <nav class="mt-4 space-y-2 text-sm font-medium text-slate-700">
+                    <a class="flex items-center justify-between rounded-xl bg-slate-900 px-4 py-3 text-white shadow-lg shadow-slate-900/20" href="#urun-girisi">
+                        <span>@(Model.IsEditing ? "Ürünü Düzenle" : "Yeni Ürün Girişi")</span>
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-4 w-4">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M5 12h14M12 5l7 7-7 7" />
+                        </svg>
+                    </a>
+                    <div class="flex flex-col gap-2 rounded-xl bg-slate-100/70 px-4 py-3">
+                        <a class="text-left text-slate-600 transition hover:text-slate-900" href="@Url.Action("Index", "Admin")">Yeni ürün oluştur</a>
+                        @if (Model.ProductId.HasValue)
+                        {
+                            <span class="text-xs font-medium uppercase tracking-wide text-emerald-600">Aktif düzenleme: #@Model.ProductId</span>
+                        }
+                    </div>
+                </nav>
+            </div>
+            <div class="rounded-3xl border border-slate-200 bg-white p-6 shadow-lg shadow-slate-200/30">
+                <h3 class="text-sm font-semibold uppercase tracking-wide text-slate-500">Ürün Bul</h3>
+                <form asp-action="Index" method="get" class="mt-4 space-y-3">
+                    <input type="text" name="search" value="@Model.SearchTerm" class="w-full rounded-2xl border border-slate-200 bg-white/80 p-3 text-sm text-slate-900 focus:border-slate-400 focus:outline-none focus:ring-2 focus:ring-slate-200" placeholder="İsim veya ID ile ara" />
+                    <div class="flex gap-2">
+                        <button type="submit" class="inline-flex flex-1 items-center justify-center gap-2 rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white shadow-lg shadow-slate-900/20 transition hover:bg-slate-800">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="m21 21-4.35-4.35M11 18a7 7 0 1 0 0-14 7 7 0 0 0 0 14z" />
+                            </svg>
+                            Ara
+                        </button>
+                        <a href="@Url.Action("Index", "Admin")" class="inline-flex items-center justify-center rounded-full border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-slate-400 hover:text-slate-900">Temizle</a>
+                    </div>
+                </form>
+                <div class="mt-5 space-y-2">
+                    @if (Model.SearchResults?.Count > 0)
+                    {
+                        <ul class="space-y-2 text-sm text-slate-700">
+                            @foreach (var item in Model.SearchResults)
+                            {
+                                var imagePath = string.IsNullOrWhiteSpace(item.ImageUrl)
+                                    ? Url.Content("~/img/placeholder-image.svg")
+                                    : Url.Content($"~/img/{item.ImageUrl}");
+                                <li>
+                                    <a class="flex items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50/80 px-3 py-2 transition hover:border-slate-300 hover:bg-slate-100" href="@Url.Action("Index", "Admin", new { productId = item.Id, search = Model.SearchTerm })">
+                                        <span class="flex items-center gap-3">
+                                            <span class="h-9 w-9 overflow-hidden rounded-xl border border-slate-200 bg-white">
+                                                <img src="@imagePath" alt="@item.Name" class="h-full w-full object-cover" />
+                                            </span>
+                                            <span>
+                                                <span class="block font-semibold">@item.Name</span>
+                                                <span class="text-xs text-slate-500">@item.Price.ToString("C", new System.Globalization.CultureInfo("tr-TR"))</span>
+                                            </span>
+                                        </span>
+                                        <span class="text-xs font-semibold uppercase tracking-wide text-slate-500">Düzenle</span>
+                                    </a>
+                                </li>
+                            }
+                        </ul>
+                    }
+                    else
+                    {
+                        <p class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 px-3 py-4 text-center text-xs text-slate-500">Arama kriterlerine uygun ürün bulunamadı.</p>
+                    }
+                </div>
+            </div>
+            <div class="rounded-3xl border border-amber-200 bg-amber-50 p-6 shadow-inner">
+                <h3 class="text-sm font-semibold uppercase tracking-wide text-amber-700">İpucu</h3>
+                <p class="mt-3 text-sm leading-6 text-amber-900">
+                    Ürün görseli yüksek çözünürlüklü olmalı (en az 1200px) ve sade bir arka plan içermelidir. Fiyatı girerken vergiler dahil değeri tercih edin.
+                </p>
+            </div>
+        </aside>
 
-<section id="urun-girisi" class="space-y-6">
+        <section id="urun-girisi" class="space-y-6">
     <header class="flex flex-col gap-3 rounded-3xl border border-slate-200 bg-white/90 px-8 py-6 shadow-xl shadow-slate-200/60">
         <div class="flex flex-wrap items-center justify-between gap-4">
             <div>
-                <h1 class="text-2xl font-semibold text-slate-900">Yeni Ürün Ekle</h1>
-                <p class="mt-1 text-sm text-slate-500">Mağazanıza eklenecek yeni ürünün temel bilgilerini eksiksiz girin. Kaydetmeden önce önizlemeyi kullanarak görsel ve içerik uyumunu kontrol edin.</p>
+                <h1 class="text-2xl font-semibold text-slate-900">@(Model.IsEditing ? "Ürün Bilgilerini Güncelle" : "Yeni Ürün Ekle")</h1>
+                <p class="mt-1 text-sm text-slate-500">
+                    @(Model.IsEditing
+                        ? "Seçili ürünün bilgilerini düzenleyebilir, görselini güncelleyebilirsiniz."
+                        : "Mağazanıza eklenecek yeni ürünün temel bilgilerini eksiksiz girin. Kaydetmeden önce önizlemeyi kullanarak görsel ve içerik uyumunu kontrol edin.")
+                </p>
             </div>
-            <div class="flex items-center gap-2 rounded-full bg-emerald-50 px-4 py-2 text-sm font-semibold text-emerald-700">
-                <span class="h-2 w-2 rounded-full bg-emerald-500"></span>
-                Form Hazır
+            <div class="flex items-center gap-2 rounded-full @(Model.IsEditing ? "bg-sky-50 text-sky-700" : "bg-emerald-50 text-emerald-700") px-4 py-2 text-sm font-semibold">
+                <span class="h-2 w-2 rounded-full @(Model.IsEditing ? "bg-sky-500" : "bg-emerald-500")"></span>
+                @(Model.IsEditing ? "Düzenleme Modu" : "Form Hazır")
             </div>
         </div>
         <div class="grid gap-3 text-xs text-slate-500 sm:grid-cols-3">
@@ -62,6 +121,9 @@
     <form asp-action="CreateProduct" method="post" enctype="multipart/form-data" class="grid gap-8 xl:grid-cols-[minmax(0,1fr)_360px]">
         @Html.AntiForgeryToken()
         <div asp-validation-summary="ModelOnly" class="space-y-1 text-sm text-red-600" role="alert"></div>
+        <input asp-for="ProductId" type="hidden" />
+        <input asp-for="ExistingImageUrl" type="hidden" />
+        <input asp-for="SearchTerm" type="hidden" />
         <div class="space-y-8">
             <div class="rounded-3xl border border-slate-200 bg-white p-8 shadow-lg shadow-slate-200/50">
                 <h2 class="text-lg font-semibold text-slate-900">Ürün Görseli</h2>
@@ -71,7 +133,7 @@
                     <label asp-for="Image" class="block text-sm font-medium text-slate-700"></label>
                     <div class="mt-2 flex flex-col items-center justify-center gap-4 rounded-3xl border-2 border-dashed border-slate-200 bg-slate-50/80 p-8 text-center transition hover:border-slate-300">
                         <div class="flex h-32 w-32 items-center justify-center overflow-hidden rounded-2xl bg-white shadow-inner">
-                            <img id="imagePreview" src="/img/placeholder-image.svg" alt="Ürün önizleme" class="h-full w-full object-cover" />
+                            <img id="imagePreview" src="@existingImagePath" alt="Ürün önizleme" class="h-full w-full object-cover" />
                         </div>
                         <div class="space-y-2 text-sm text-slate-500">
                             <p class="font-medium text-slate-700">Görselinizi sürükleyip bırakın veya tıklayarak seçin</p>
@@ -145,13 +207,13 @@
                 <div class="mt-4 space-y-3 rounded-2xl border border-slate-100 bg-slate-50/80 p-4">
                     <div class="flex items-start gap-3">
                         <div class="h-16 w-16 overflow-hidden rounded-xl border border-slate-200 bg-white shadow-inner">
-                            <img id="cardPreviewImage" src="/img/placeholder-image.svg" alt="Kart önizleme" class="h-full w-full object-cover" />
+                            <img id="cardPreviewImage" src="@existingImagePath" alt="Kart önizleme" class="h-full w-full object-cover" />
                         </div>
                         <div class="flex-1">
-                            <p class="text-sm font-semibold text-slate-800" id="cardPreviewName">Ürün adı buraya gelecek</p>
-                            <p class="text-xs text-slate-500" id="cardPreviewDescription">Kısa açıklama burada görünecek.</p>
+                            <p class="text-sm font-semibold text-slate-800" id="cardPreviewName">@(string.IsNullOrWhiteSpace(Model.Name) ? "Ürün adı buraya gelecek" : Model.Name)</p>
+                            <p class="text-xs text-slate-500" id="cardPreviewDescription">@(string.IsNullOrWhiteSpace(Model.Description) ? "Kısa açıklama burada görünecek." : Model.Description)</p>
                         </div>
-                        <p class="text-base font-semibold text-emerald-600" id="cardPreviewPrice">₺0,00</p>
+                        <p class="text-base font-semibold text-emerald-600" id="cardPreviewPrice">@((Model.Price ?? 0m).ToString("C", new System.Globalization.CultureInfo("tr-TR")))</p>
                     </div>
                 </div>
             </div>
@@ -160,7 +222,7 @@
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" class="h-5 w-5">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 5v14m-7-7h14" />
                 </svg>
-                Kaydet ve Devam Et
+                @(Model.IsEditing ? "Değişiklikleri Kaydet" : "Kaydet ve Devam Et")
             </button>
         </div>
     </form>
@@ -219,5 +281,23 @@
             descriptionCounter.textContent = `${value.length} / 1000`;
             cardPreviewDescription.textContent = value || 'Kısa açıklama burada görünecek.';
         });
+
+        if (imagePreview && cardPreviewImage) {
+            cardPreviewImage.src = imagePreview.src;
+        }
+
+        if (nameInput) {
+            cardPreviewName.textContent = nameInput.value.trim() || 'Ürün adı buraya gelecek';
+        }
+
+        if (priceInput) {
+            cardPreviewPrice.textContent = formatCurrency(priceInput.value);
+        }
+
+        if (descriptionInput) {
+            const value = descriptionInput.value.trim();
+            descriptionCounter.textContent = `${value.length} / 1000`;
+            cardPreviewDescription.textContent = value || 'Kısa açıklama burada görünecek.';
+        }
     </script>
 }


### PR DESCRIPTION
## Summary
- add product search and edit workflow to the admin product entry page
- persist product updates and save uploaded images using the product name as the file name
- refresh the admin index UI with a searchable sidebar and contextual previews

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d8f534d7bc83208beb681fb83f42b7