### PR TITLE
Integrate distant selling agreement into checkout flow

### DIFF
--- a/ECommerceBatteryShop/Controllers/HomeController.cs
+++ b/ECommerceBatteryShop/Controllers/HomeController.cs
@@ -139,7 +139,7 @@ namespace ECommerceBatteryShop.Controllers
         }
         public IActionResult DistantSelling()
         {
-            return View();
+            return RedirectToAction("DistantSelling", "Cart");
         }
     }
 }

--- a/ECommerceBatteryShop/Views/Cart/Checkout.cshtml
+++ b/ECommerceBatteryShop/Views/Cart/Checkout.cshtml
@@ -1,3 +1,4 @@
+@using System.Linq
 @{
     ViewBag.Title = "Checkout";
 }
@@ -6,6 +7,12 @@
     decimal subTotal = Model.SubTotal;
     decimal tax = subTotal * 0.2m;
     decimal shipping = Model.ShippingCost;
+    var defaultAddressId = Model.Addresses.FirstOrDefault(a => a.IsDefault)?.Id
+        ?? Model.Addresses.FirstOrDefault()?.Id;
+    var contractUrl = defaultAddressId.HasValue
+        ? Url.Action("DistantSelling", "Cart", new { addressId = defaultAddressId.Value, shipping })
+        : Url.Action("DistantSelling", "Cart", new { shipping });
+    contractUrl ??= "/Cart/DistantSelling";
 }
 <main x-data class="bg-white min-h-screen pt-10 pb-24">
     <div class="mx-auto max-w-5xl px-4">
@@ -107,7 +114,13 @@
                     <div class="mt-6 flex items-center gap-2">
                         <input id="sozlesme" type="checkbox" class="rounded border-slate-300">
                         <label for="sozlesme" class="text-xs text-slate-600">
-                            Ön bilgilendirme formu ve Mesafeli satış sözleşmesini onaylıyorum.
+                            Ön bilgilendirme formu ve
+                            <a href="@contractUrl"
+                               target="_blank"
+                               rel="noopener"
+                               class="text-amber-600 hover:text-amber-700 underline font-medium">
+                                Mesafeli satış sözleşmesini okudum, onaylıyorum
+                            </a>.
                         </label>
                     </div>
 


### PR DESCRIPTION
## Summary
- add a CartController.DistantSelling endpoint that builds the mesafeli satış sözleşmesi model from the active cart, user details, and addresses
- update the checkout agreement checkbox to link to the new contract view while preserving address context
- redirect the legacy Home/DistantSelling route to the cart-based implementation for consistent behavior

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da782a67048320ab6c22e8692fe622