### PR TITLE
Integrate iyzico payment processing for checkout

### DIFF
--- a/ECommerceBatteryShop/Controllers/CheckoutController.cs
+++ b/ECommerceBatteryShop/Controllers/CheckoutController.cs
@@ -1,0 +1,363 @@
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Text.RegularExpressions;
+using ECommerceBatteryShop.DataAccess.Abstract;
+using ECommerceBatteryShop.Domain.Entities;
+using ECommerceBatteryShop.Models;
+using ECommerceBatteryShop.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ECommerceBatteryShop.Controllers;
+
+[Authorize]
+[AutoValidateAntiforgeryToken]
+public class CheckoutController : Controller
+{
+    private const decimal DefaultExchangeRate = 41.3m;
+    private const decimal KdvRate = 0.20m;
+    private const decimal ShippingFee = 150m;
+
+    private readonly ICartService _cartService;
+    private readonly ICurrencyService _currencyService;
+    private readonly IAddressRepository _addressRepository;
+    private readonly IIyzicoPaymentService _paymentService;
+    private readonly ILogger<CheckoutController> _logger;
+
+    public CheckoutController(
+        ICartService cartService,
+        ICurrencyService currencyService,
+        IAddressRepository addressRepository,
+        IIyzicoPaymentService paymentService,
+        ILogger<CheckoutController> logger)
+    {
+        _cartService = cartService;
+        _currencyService = currencyService;
+        _addressRepository = addressRepository;
+        _paymentService = paymentService;
+        _logger = logger;
+    }
+
+    [HttpPost]
+    [AllowAnonymous]
+    public async Task<IActionResult> PlaceOrder([FromForm] PlaceOrderInputModel input, CancellationToken cancellationToken)
+    {
+        if (!ModelState.IsValid)
+        {
+            var firstError = ModelState.Values.SelectMany(v => v.Errors).FirstOrDefault()?.ErrorMessage
+                            ?? "Geçersiz istek.";
+            return BadRequest(new { success = false, message = firstError });
+        }
+
+        if (string.Equals(input.PaymentMethod, "iban", StringComparison.OrdinalIgnoreCase))
+        {
+            return Ok(new
+            {
+                success = true,
+                message = "Havale/EFT seçildi. Siparişinizi tamamlamak için belirtilen IBAN’a ödeme yapabilirsiniz."
+            });
+        }
+
+        if (!string.Equals(input.PaymentMethod, "card_new", StringComparison.OrdinalIgnoreCase))
+        {
+            return BadRequest(new { success = false, message = "Seçilen ödeme yöntemi şu anda desteklenmiyor." });
+        }
+
+        if (!TryResolveOwner(out var owner, out var errorResult))
+        {
+            return errorResult ?? BadRequest(new { success = false, message = "Sepet bulunamadı." });
+        }
+
+        var cart = await _cartService.GetAsync(owner, createIfMissing: false, cancellationToken);
+        if (cart is null || cart.Items.Count == 0)
+        {
+            return BadRequest(new { success = false, message = "Sepetiniz boş olduğu için ödeme alınamadı." });
+        }
+
+        if (!TryParseCard(input, out var cardInfo, out var cardError))
+        {
+            return BadRequest(new { success = false, message = cardError ?? "Kart bilgileri eksik veya hatalı." });
+        }
+
+        var fxRate = await _currencyService.GetCachedUsdTryAsync(cancellationToken) ?? DefaultExchangeRate;
+
+        var lineItems = new List<IyzicoBasketItem>();
+        decimal basketTotal = 0m;
+        foreach (var item in cart.Items)
+        {
+            var unitPriceTry = item.UnitPrice * (1 + KdvRate) * fxRate;
+            var linePrice = decimal.Round(unitPriceTry * item.Quantity, 2, MidpointRounding.AwayFromZero);
+            basketTotal += linePrice;
+            lineItems.Add(new IyzicoBasketItem
+            {
+                Id = item.ProductId.ToString(CultureInfo.InvariantCulture),
+                Name = item.Product?.Name ?? $"Ürün #{item.ProductId}",
+                Price = linePrice
+            });
+        }
+
+        if (lineItems.Count == 0)
+        {
+            return BadRequest(new { success = false, message = "Ödeme için sepet ürünü bulunamadı." });
+        }
+
+        var paidPrice = basketTotal + ShippingFee;
+
+        var buyerContext = await BuildBuyerContextAsync(owner, cart, cancellationToken);
+
+        var paymentModel = new IyzicoPaymentModel
+        {
+            ConversationId = Guid.NewGuid().ToString("N"),
+            BasketId = cart.Id.ToString(CultureInfo.InvariantCulture),
+            Price = basketTotal,
+            PaidPrice = paidPrice,
+            Card = cardInfo,
+            Buyer = buyerContext.Buyer,
+            BillingAddress = buyerContext.Billing,
+            ShippingAddress = buyerContext.Shipping,
+            Items = lineItems
+        };
+
+        var result = await _paymentService.CreatePaymentAsync(paymentModel, cancellationToken);
+        if (!result.Success)
+        {
+            var errorMessage = string.IsNullOrWhiteSpace(result.ErrorMessage)
+                ? "Ödeme sırasında bir hata oluştu. Lütfen tekrar deneyin."
+                : result.ErrorMessage;
+            return StatusCode((int)HttpStatusCode.BadGateway, new { success = false, message = errorMessage });
+        }
+
+        await _cartService.RemoveAllAsync(owner, cancellationToken);
+        _logger.LogInformation("Iyzico payment completed successfully. ConversationId: {ConversationId}", paymentModel.ConversationId);
+
+        return Ok(new
+        {
+            success = true,
+            message = "Ödemeniz başarıyla tamamlandı. Siparişiniz işleme alındı.",
+            raw = result.RawResponse
+        });
+    }
+
+    private bool TryResolveOwner(out CartOwner owner, out IActionResult? errorResult)
+    {
+        owner = default;
+        errorResult = null;
+
+        if (User.Identity?.IsAuthenticated == true)
+        {
+            var userIdClaim = User.FindFirst("sub") ?? User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier);
+            if (userIdClaim is not null && int.TryParse(userIdClaim.Value, out var userId))
+            {
+                owner = CartOwner.FromUser(userId);
+                return true;
+            }
+
+            errorResult = BadRequest(new { success = false, message = "Kullanıcı kimliği doğrulanamadı." });
+            return false;
+        }
+
+        if (!Request.Cookies.TryGetValue("ANON_ID", out var anonId) || string.IsNullOrWhiteSpace(anonId))
+        {
+            errorResult = BadRequest(new { success = false, message = "Misafir sepeti bulunamadı." });
+            return false;
+        }
+
+        owner = CartOwner.FromAnon(anonId);
+        return true;
+    }
+
+    private async Task<(IyzicoBuyer Buyer, IyzicoAddress Billing, IyzicoAddress Shipping)> BuildBuyerContextAsync(
+        CartOwner owner,
+        Cart cart,
+        CancellationToken cancellationToken)
+    {
+        Address? address = null;
+        if (owner.UserId is int userId)
+        {
+            address = await ResolveAddressAsync(userId, cancellationToken);
+        }
+
+        var defaultName = address is null ? "Müşteri" : address.Name;
+        var defaultSurname = address is null ? "" : address.Surname;
+        var contactName = string.Join(' ', new[] { defaultName, defaultSurname }.Where(s => !string.IsNullOrWhiteSpace(s))).Trim();
+        if (string.IsNullOrWhiteSpace(contactName))
+        {
+            contactName = owner.UserId?.ToString(CultureInfo.InvariantCulture) ?? "Misafir";
+        }
+
+        var fullAddress = address is null
+            ? "Adres belirtilmedi"
+            : string.Join(' ', new[]
+            {
+                address.FullAddress,
+                address.Neighbourhood,
+                address.State,
+                address.City
+            }.Where(s => !string.IsNullOrWhiteSpace(s)));
+
+        var phone = NormalizePhone(address?.PhoneNumber) ?? "+900000000000";
+        var email = User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value;
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            email = "info@dayilyenerji.com";
+        }
+
+        var buyer = new IyzicoBuyer
+        {
+            Id = owner.UserId?.ToString(CultureInfo.InvariantCulture) ?? cart.AnonId ?? Guid.NewGuid().ToString("N"),
+            Name = string.IsNullOrWhiteSpace(defaultName) ? "Müşteri" : defaultName,
+            Surname = string.IsNullOrWhiteSpace(defaultSurname) ? "" : defaultSurname,
+            GsmNumber = phone,
+            Email = email,
+            IdentityNumber = DeriveIdentityNumber(address),
+            RegistrationAddress = fullAddress,
+            City = address?.City ?? "Ankara",
+            Country = "Turkey",
+            ZipCode = "00000",
+            Ip = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "127.0.0.1"
+        };
+
+        var billing = new IyzicoAddress
+        {
+            ContactName = contactName,
+            City = address?.City ?? "Ankara",
+            Country = "Turkey",
+            Description = fullAddress,
+            ZipCode = "00000"
+        };
+
+        var shipping = new IyzicoAddress
+        {
+            ContactName = contactName,
+            City = address?.City ?? "Ankara",
+            Country = "Turkey",
+            Description = fullAddress,
+            ZipCode = "00000"
+        };
+
+        return (buyer, billing, shipping);
+    }
+
+    private async Task<Address?> ResolveAddressAsync(int userId, CancellationToken cancellationToken)
+    {
+        var addresses = await _addressRepository.GetByUserAsync(userId, cancellationToken);
+        return addresses.FirstOrDefault(a => a.IsDefault) ?? addresses.FirstOrDefault();
+    }
+
+    private static bool TryParseCard(PlaceOrderInputModel input, out IyzicoPaymentCard card, out string? error)
+    {
+        card = null!;
+        error = null;
+
+        var number = SanitizeDigits(input.Number);
+        if (string.IsNullOrWhiteSpace(input.Name) || string.IsNullOrWhiteSpace(number) || string.IsNullOrWhiteSpace(input.Cvc))
+        {
+            error = "Kart bilgileri eksik.";
+            return false;
+        }
+
+        if (number.Length < 13 || number.Length > 19)
+        {
+            error = "Kart numarası geçerli değil.";
+            return false;
+        }
+
+        var cvc = SanitizeDigits(input.Cvc);
+        if (cvc.Length < 3 || cvc.Length > 4)
+        {
+            error = "CVC bilgisi geçerli değil.";
+            return false;
+        }
+
+        if (!TryParseExpiry(input.Exp, out var month, out var year))
+        {
+            error = "Son kullanma tarihi geçerli değil.";
+            return false;
+        }
+
+        card = new IyzicoPaymentCard
+        {
+            HolderName = input.Name.Trim(),
+            Number = number,
+            ExpireMonth = month,
+            ExpireYear = year,
+            Cvc = cvc,
+            RegisterCard = input.Save
+        };
+
+        return true;
+    }
+
+    private static bool TryParseExpiry(string? exp, out string month, out string year)
+    {
+        month = string.Empty;
+        year = string.Empty;
+        if (string.IsNullOrWhiteSpace(exp))
+        {
+            return false;
+        }
+
+        var match = Regex.Match(exp, @"^(?<m>\d{1,2})\s*/\s*(?<y>\d{2,4})$");
+        if (!match.Success)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(match.Groups["m"].Value, out var m) || m < 1 || m > 12)
+        {
+            return false;
+        }
+
+        if (!int.TryParse(match.Groups["y"].Value, out var y))
+        {
+            return false;
+        }
+
+        if (y < 100)
+        {
+            y += 2000;
+        }
+
+        month = m.ToString("00", CultureInfo.InvariantCulture);
+        year = y.ToString(CultureInfo.InvariantCulture);
+        return true;
+    }
+
+    private static string DeriveIdentityNumber(Address? address)
+    {
+        var digits = SanitizeDigits(address?.PhoneNumber);
+        if (!string.IsNullOrWhiteSpace(digits) && digits.Length >= 11)
+        {
+            return digits[^11..];
+        }
+
+        return "11111111111";
+    }
+
+    private static string? NormalizePhone(string? phone)
+    {
+        var digits = SanitizeDigits(phone);
+        if (string.IsNullOrWhiteSpace(digits))
+        {
+            return null;
+        }
+
+        if (!digits.StartsWith("90", StringComparison.Ordinal))
+        {
+            digits = "90" + digits;
+        }
+
+        return "+" + digits;
+    }
+
+    private static string SanitizeDigits(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
+        return new string(value.Where(char.IsDigit).ToArray());
+    }
+}

--- a/ECommerceBatteryShop/Models/PlaceOrderInputModel.cs
+++ b/ECommerceBatteryShop/Models/PlaceOrderInputModel.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ECommerceBatteryShop.Models;
+
+public class PlaceOrderInputModel
+{
+    [Required]
+    public string PaymentMethod { get; set; } = string.Empty;
+
+    public string? Name { get; set; }
+
+    public string? Number { get; set; }
+
+    public string? Exp { get; set; }
+
+    public string? Cvc { get; set; }
+
+    public string? CardId { get; set; }
+
+    public bool Save { get; set; }
+}

--- a/ECommerceBatteryShop/Options/IyzicoOptions.cs
+++ b/ECommerceBatteryShop/Options/IyzicoOptions.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace ECommerceBatteryShop.Options;
+
+public class IyzicoOptions
+{
+    [Required]
+    public string ApiKey { get; set; } = string.Empty;
+
+    [Required]
+    public string SecretKey { get; set; } = string.Empty;
+
+    [Required]
+    public string BaseUrl { get; set; } = string.Empty;
+
+    public string? CallbackUrl { get; set; }
+}

--- a/ECommerceBatteryShop/Program.cs
+++ b/ECommerceBatteryShop/Program.cs
@@ -28,6 +28,7 @@ builder.Services.AddDbContext<BatteryShopContext>(opt =>
   builder.Services.AddScoped<IUserService, UserService>();
   builder.Services.AddScoped<ICartService, CartService>();
   builder.Services.AddScoped<IFavoritesService, FavoritesService>();
+  builder.Services.AddScoped<IIyzicoPaymentService, IyzicoPaymentService>();
 builder.Services.AddMemoryCache();
 
 // Options
@@ -35,6 +36,15 @@ builder.Services.AddOptions<CurrencyOptions>()
     .Bind(builder.Configuration.GetSection("Currency"))
     .Validate(o => !string.IsNullOrWhiteSpace(o.BaseUrl) && !string.IsNullOrWhiteSpace(o.ApiKey),
               "Currency:BaseUrl and Currency:ApiKey are required")
+    .ValidateOnStart();
+
+builder.Services.AddOptions<IyzicoOptions>()
+    .Bind(builder.Configuration.GetSection("Iyzico"))
+    .Validate(o =>
+        !string.IsNullOrWhiteSpace(o.ApiKey) &&
+        !string.IsNullOrWhiteSpace(o.SecretKey) &&
+        !string.IsNullOrWhiteSpace(o.BaseUrl),
+        "Iyzico configuration (ApiKey, SecretKey, BaseUrl) is required")
     .ValidateOnStart();
 
 // Typed HttpClient for currency service

--- a/ECommerceBatteryShop/Services/IyzicoPaymentService.cs
+++ b/ECommerceBatteryShop/Services/IyzicoPaymentService.cs
@@ -1,0 +1,189 @@
+using System.Globalization;
+using System.Linq;
+using ECommerceBatteryShop.Options;
+using Iyzipay.Model;
+using Iyzipay.Request;
+using Microsoft.Extensions.Options;
+
+namespace ECommerceBatteryShop.Services;
+
+public interface IIyzicoPaymentService
+{
+    Task<IyzicoPaymentResult> CreatePaymentAsync(IyzicoPaymentModel model, CancellationToken cancellationToken = default);
+}
+
+public class IyzicoPaymentService : IIyzicoPaymentService
+{
+    private readonly Iyzipay.Options _options;
+    private readonly ILogger<IyzicoPaymentService> _logger;
+
+    public IyzicoPaymentService(IOptions<IyzicoOptions> options, ILogger<IyzicoPaymentService> logger)
+    {
+        var value = options.Value ?? throw new ArgumentNullException(nameof(options));
+        _options = new Iyzipay.Options
+        {
+            ApiKey = value.ApiKey,
+            SecretKey = value.SecretKey,
+            BaseUrl = value.BaseUrl
+        };
+        _logger = logger;
+    }
+
+    public async Task<IyzicoPaymentResult> CreatePaymentAsync(IyzicoPaymentModel model, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(model);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var request = new CreatePaymentRequest
+        {
+            Locale = Locale.TR.ToString(),
+            ConversationId = model.ConversationId,
+            Price = ToPrice(model.Price),
+            PaidPrice = ToPrice(model.PaidPrice),
+            BasketId = model.BasketId,
+            Installment = model.Installment,
+            Currency = model.Currency,
+            PaymentChannel = model.PaymentChannel,
+            PaymentGroup = model.PaymentGroup
+        };
+
+        request.PaymentCard = new PaymentCard
+        {
+            CardHolderName = model.Card.HolderName,
+            CardNumber = model.Card.Number,
+            ExpireMonth = model.Card.ExpireMonth,
+            ExpireYear = model.Card.ExpireYear,
+            Cvc = model.Card.Cvc,
+            RegisterCard = model.Card.RegisterCard ? 1 : 0
+        };
+
+        request.Buyer = new Buyer
+        {
+            Id = model.Buyer.Id,
+            Name = model.Buyer.Name,
+            Surname = model.Buyer.Surname,
+            GsmNumber = model.Buyer.GsmNumber,
+            Email = model.Buyer.Email,
+            IdentityNumber = model.Buyer.IdentityNumber,
+            RegistrationAddress = model.Buyer.RegistrationAddress,
+            City = model.Buyer.City,
+            Country = model.Buyer.Country,
+            ZipCode = model.Buyer.ZipCode,
+            Ip = model.Buyer.Ip
+        };
+
+        request.ShippingAddress = new Address
+        {
+            ContactName = model.ShippingAddress.ContactName,
+            City = model.ShippingAddress.City,
+            Country = model.ShippingAddress.Country,
+            Description = model.ShippingAddress.Description,
+            ZipCode = model.ShippingAddress.ZipCode
+        };
+
+        request.BillingAddress = new Address
+        {
+            ContactName = model.BillingAddress.ContactName,
+            City = model.BillingAddress.City,
+            Country = model.BillingAddress.Country,
+            Description = model.BillingAddress.Description,
+            ZipCode = model.BillingAddress.ZipCode
+        };
+
+        request.BasketItems = model.Items.Select(item => new BasketItem
+        {
+            Id = item.Id,
+            Name = item.Name,
+            Category1 = item.Category1,
+            Category2 = item.Category2,
+            ItemType = item.ItemType,
+            Price = ToPrice(item.Price)
+        }).ToList();
+
+        try
+        {
+            var response = await Task.Run(() => Payment.Create(request, _options), cancellationToken);
+            var success = string.Equals(response.Status, "success", StringComparison.OrdinalIgnoreCase);
+            if (!success)
+            {
+                _logger.LogWarning("Iyzico payment failed. ConversationId: {ConversationId}, ErrorCode: {ErrorCode}, Message: {Message}",
+                    model.ConversationId,
+                    response.ErrorCode,
+                    response.ErrorMessage);
+            }
+
+            return new IyzicoPaymentResult(success, response.ErrorMessage, response.RawResult);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Error while creating Iyzico payment. ConversationId: {ConversationId}", model.ConversationId);
+            return new IyzicoPaymentResult(false, ex.Message, null);
+        }
+    }
+
+    private static string ToPrice(decimal value)
+        => decimal.Round(value, 2, MidpointRounding.AwayFromZero).ToString("0.00", CultureInfo.InvariantCulture);
+}
+
+public record IyzicoPaymentResult(bool Success, string? ErrorMessage, string? RawResponse);
+
+public class IyzicoPaymentModel
+{
+    public required string ConversationId { get; init; }
+    public required string BasketId { get; init; }
+    public required decimal Price { get; init; }
+    public required decimal PaidPrice { get; init; }
+    public int Installment { get; init; } = 1;
+    public string Currency { get; init; } = Currency.TRY.ToString();
+    public string PaymentChannel { get; init; } = Model.PaymentChannel.WEB.ToString();
+    public string PaymentGroup { get; init; } = Model.PaymentGroup.PRODUCT.ToString();
+    public required IyzicoPaymentCard Card { get; init; }
+    public required IyzicoBuyer Buyer { get; init; }
+    public required IyzicoAddress BillingAddress { get; init; }
+    public required IyzicoAddress ShippingAddress { get; init; }
+    public required IReadOnlyList<IyzicoBasketItem> Items { get; init; }
+}
+
+public class IyzicoPaymentCard
+{
+    public required string HolderName { get; init; }
+    public required string Number { get; init; }
+    public required string ExpireMonth { get; init; }
+    public required string ExpireYear { get; init; }
+    public required string Cvc { get; init; }
+    public bool RegisterCard { get; init; }
+}
+
+public class IyzicoBuyer
+{
+    public required string Id { get; init; }
+    public required string Name { get; init; }
+    public required string Surname { get; init; }
+    public required string GsmNumber { get; init; }
+    public required string Email { get; init; }
+    public required string IdentityNumber { get; init; }
+    public required string RegistrationAddress { get; init; }
+    public required string City { get; init; }
+    public required string Country { get; init; }
+    public string ZipCode { get; init; } = "";
+    public string Ip { get; init; } = "";
+}
+
+public class IyzicoAddress
+{
+    public required string ContactName { get; init; }
+    public required string City { get; init; }
+    public required string Country { get; init; }
+    public required string Description { get; init; }
+    public string ZipCode { get; init; } = "";
+}
+
+public class IyzicoBasketItem
+{
+    public required string Id { get; init; }
+    public required string Name { get; init; }
+    public string Category1 { get; init; } = "Elektronik";
+    public string Category2 { get; init; } = "Batarya";
+    public string ItemType { get; init; } = BasketItemType.PHYSICAL.ToString();
+    public required decimal Price { get; init; }
+}

--- a/ECommerceBatteryShop/Views/Cart/Checkout.cshtml
+++ b/ECommerceBatteryShop/Views/Cart/Checkout.cshtml
@@ -124,8 +124,21 @@
                         </label>
                     </div>
 
-                    <button type="button" @@click="placeOrder" class="mt-4 w-full h-12 rounded-xl bg-amber-300 font-semibold text-gray-900 hover:bg-amber-400 disabled:opacity-60">
-                        Siparişi onayla
+                    <template x-if="notice">
+                        <div class="mt-4 rounded-lg border p-3" :class="notice.success ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-red-200 bg-red-50 text-red-700'">
+                            <p class="text-sm font-medium" x-text="notice.message"></p>
+                        </div>
+                    </template>
+
+                    <button type="button"
+                            @@click="placeOrder"
+                            :disabled="loading"
+                            class="mt-4 w-full h-12 rounded-xl bg-amber-300 font-semibold text-gray-900 hover:bg-amber-400 disabled:opacity-60 flex items-center justify-center gap-2">
+                        <svg x-show="loading" class="h-5 w-5 animate-spin text-gray-900" viewBox="0 0 24 24" fill="none">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z"></path>
+                        </svg>
+                        <span x-text="loading ? 'İşleniyor...' : 'Siparişi onayla'"></span>
                     </button>
                 </section>
             </div>
@@ -176,27 +189,75 @@
         saved:[],
         selectedId:null,
         newCard:{name:'', number:'', exp:'', cvc:'', save:true},
+        loading:false,
+        notice:null,
         digits(s){ return (s||'').replace(/\D/g,''); },
         maskCard(){ let d=this.digits(this.newCard.number).slice(0,16); this.newCard.number=d.replace(/(\d{4})(?=\d)/g,'$1 ').trim(); },
         maskExp(){ let d=this.digits(this.newCard.exp).slice(0,4); this.newCard.exp=(d.length>=3)? d.slice(0,2)+'/'+d.slice(2) : d; },
         luhn(num){ let d=this.digits(num), s=0, alt=false; for(let i=d.length-1;i>=0;i--){ let n=+d[i]; if(alt){ n*=2; if(n>9)n-=9; } s+=n; alt=!alt; } return d.length>=13 && s%10===0; },
-        placeOrder(){
-          if(!document.getElementById('sozlesme').checked){ alert('Sözleşmeyi onaylayın.'); return; }
+        async placeOrder(){
+          if(this.loading) return;
+          this.notice = null;
+          if(!document.getElementById('sozlesme').checked){
+            this.notice = { success:false, message:'Lütfen sözleşmeyi onaylayın.' };
+            return;
+          }
           if(this.method==='card'){
-            if(this.selectedId){ htmx.ajax('POST','/Checkout/PlaceOrder',{values:{paymentMethod:'card_saved', cardId:this.selectedId}}); return; }
-            if(!this.luhn(this.newCard.number)){ alert('Kart numarası geçersiz.'); return; }
-            htmx.ajax('POST','/Checkout/PlaceOrder',{
-              values:{
-                paymentMethod:'card_new',
-                name:this.newCard.name,
-                number:this.digits(this.newCard.number),
-                exp:this.newCard.exp,
-                cvc:this.newCard.cvc,
-                save:this.newCard.save
-              }
+            if(this.selectedId){
+              this.notice = { success:false, message:'Kayıtlı kart ile ödeme henüz desteklenmiyor.' };
+              return;
+            }
+            if(!this.luhn(this.newCard.number)){
+              this.notice = { success:false, message:'Kart numarası geçersiz görünüyor.' };
+              return;
+            }
+            await this.send({
+              paymentMethod:'card_new',
+              name:this.newCard.name,
+              number:this.digits(this.newCard.number),
+              exp:this.newCard.exp,
+              cvc:this.newCard.cvc,
+              save:this.newCard.save
             });
           } else if(this.method==='iban'){
-            htmx.ajax('POST','/Checkout/PlaceOrder',{values:{paymentMethod:'iban'}});
+            await this.send({ paymentMethod:'iban' });
+          }
+        },
+        async send(payload){
+          const tokenEl = document.querySelector('meta[name="request-verification-token"]');
+          const headers = { 'Content-Type':'application/x-www-form-urlencoded' };
+          if(tokenEl){ headers['RequestVerificationToken'] = tokenEl.content; }
+          const body = new URLSearchParams();
+          Object.entries(payload).forEach(([key,value]) => {
+            if(Array.isArray(value)) return;
+            body.append(key, value ?? '');
+          });
+          this.loading = true;
+          try {
+            const response = await fetch('/Checkout/PlaceOrder', {
+              method:'POST',
+              headers,
+              body
+            });
+            let data = null;
+            try {
+              data = await response.json();
+            } catch {}
+            if(!response.ok || !data || !data.success){
+              const message = data?.message || 'Ödeme sırasında bir sorun oluştu. Lütfen tekrar deneyin.';
+              this.notice = { success:false, message };
+              return;
+            }
+            this.notice = { success:true, message: data.message || 'Ödemeniz başarıyla tamamlandı.' };
+            if(data.redirectUrl){
+              window.location.href = data.redirectUrl;
+            } else {
+              setTimeout(() => window.location.href = '/', 2000);
+            }
+          } catch (err){
+            this.notice = { success:false, message:'Beklenmeyen bir hata oluştu. Lütfen tekrar deneyin.' };
+          } finally {
+            this.loading = false;
           }
         }
       }

--- a/ECommerceBatteryShop/appsettings.Development.json
+++ b/ECommerceBatteryShop/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Iyzico": {
+    "ApiKey": "",
+    "SecretKey": "",
+    "BaseUrl": "https://sandbox-api.iyzipay.com",
+    "CallbackUrl": ""
   }
 }


### PR DESCRIPTION
## Summary
- add Iyzipay configuration options, registration, and a payment service wrapper for Iyzico
- implement a checkout endpoint that builds basket details from the cart and calls Iyzico to charge cards
- modernize the checkout page UI to submit payments via fetch with loading state and surface API responses; add local Iyzico config scaffold

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd09f903c8320a310a734c1a8182f