### PR TITLE
Add IBAN order creation to checkout flow

### DIFF
--- a/ECommerceBatteryShop/Program.cs
+++ b/ECommerceBatteryShop/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddDbContext<BatteryShopContext>(opt =>
   builder.Services.AddScoped<ICartRepository, CartRepository>();
   builder.Services.AddScoped<ICategoryRepository, CategoryRepository>();
   builder.Services.AddScoped<IAddressRepository, AddressRepository>();
+  builder.Services.AddScoped<IOrderRepository, OrderRepository>();
   builder.Services.AddScoped<IUserService, UserService>();
   builder.Services.AddScoped<ICartService, CartService>();
   builder.Services.AddScoped<IFavoritesService, FavoritesService>();


### PR DESCRIPTION
## Summary
- create IBAN order flow within the checkout controller by persisting orders with generated numbers, totals, and default status
- resolve the cart before payment handling and clear it after successful IBAN order creation while logging the outcome
- register the order repository in the service container for dependency injection

## Testing
- dotnet build *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de1cfe25c08320b6f08c82980ed4f5