### PR TITLE
Add stock availability indicators to add-to-cart actions

### DIFF
--- a/ECommerceBatteryShop.DataAccess/Concrete/ProductRepository.cs
+++ b/ECommerceBatteryShop.DataAccess/Concrete/ProductRepository.cs
@@ -36,6 +36,7 @@ namespace ECommerceBatteryShop.DataAccess.Concrete
             {
                 IQueryable<Product> query = _ctx.Products
       .AsNoTracking()
+      .Include(p => p.Inventory)
       .Include(p => p.Variants)
       .OrderBy(p => p.Id)
       .ThenBy(p => p.Name);
@@ -75,6 +76,7 @@ namespace ECommerceBatteryShop.DataAccess.Concrete
         public async Task<Product?> GetProductAsync(int id, CancellationToken ct)
         {
             return await _ctx.Products
+                .Include(p => p.Inventory)
                 .FirstOrDefaultAsync(p => p.Id == id, ct);
         }
 
@@ -91,7 +93,9 @@ namespace ECommerceBatteryShop.DataAccess.Concrete
 
             try
             {
-                IQueryable<Product> query = _ctx.Products.AsNoTracking();
+                IQueryable<Product> query = _ctx.Products
+                    .AsNoTracking()
+                    .Include(p => p.Inventory);
 
                 if (!string.IsNullOrWhiteSpace(searchTerm))
                 {
@@ -167,14 +171,10 @@ namespace ECommerceBatteryShop.DataAccess.Concrete
             if (page <= 0) page = 1;
             if (pageSize <= 0) pageSize = 30;
 
-            var baseQuery = _ctx.ProductCategories
+            var query = _ctx.Products
                 .AsNoTracking()
-                .Where(pc => pc.CategoryId == categoryId)
-                .Select(pc => pc.Product);
-
-            var query = baseQuery
-                .Where(p => p != null)
-                .Select(p => p!);
+                .Include(p => p.Inventory)
+                .Where(p => p.ProductCategories.Any(pc => pc.CategoryId == categoryId));
 
             if (minUsd.HasValue)
             {
@@ -203,6 +203,7 @@ namespace ECommerceBatteryShop.DataAccess.Concrete
         {
             return await _ctx.Products
                 .AsNoTracking()
+                .Include(p => p.Inventory)
                 .OrderByDescending(p => p.Id)
                 .Take(8)
                 .ToListAsync();

--- a/ECommerceBatteryShop/Controllers/FavoritesController.cs
+++ b/ECommerceBatteryShop/Controllers/FavoritesController.cs
@@ -90,7 +90,8 @@ namespace ECommerceBatteryShop.Controllers
                         ProductId = i.ProductId,
                         UnitPrice = (decimal)priceWithKdvAndRate,
                         Name = i.Product?.Name ?? string.Empty,
-                        ImageUrl = i.Product?.ImageUrl
+                        ImageUrl = i.Product?.ImageUrl,
+                        StockQuantity = i.Product?.Inventory?.Quantity ?? 0
                     };
                 }).ToList()
             };

--- a/ECommerceBatteryShop/Controllers/HomeController.cs
+++ b/ECommerceBatteryShop/Controllers/HomeController.cs
@@ -55,7 +55,8 @@ namespace ECommerceBatteryShop.Controllers
                 ImageUrl = p.ImageUrl ?? string.Empty,
                 ExtraAmount = p.ExtraAmount,
                 Description = p.Description ?? string.Empty,
-                IsFavorite = favoriteIds.Contains(p.Id)
+                IsFavorite = favoriteIds.Contains(p.Id),
+                StockQuantity = p.Inventory?.Quantity ?? 0
             };
             var plan = new[]
             {

--- a/ECommerceBatteryShop/Controllers/ProductController.cs
+++ b/ECommerceBatteryShop/Controllers/ProductController.cs
@@ -87,7 +87,8 @@ namespace ECommerceBatteryShop.Controllers
                 Price = (_currency.ConvertUsdToTry(p.Price /* USD */, fx) + p.ExtraAmount)* (1 + KdvRate), // displayed in TRY or USD
                 Rating = p.Rating,
                 ImageUrl = p.ImageUrl,
-                IsFavorite = favoriteIds.Contains(p.Id)
+                IsFavorite = favoriteIds.Contains(p.Id),
+                StockQuantity = p.Inventory?.Quantity ?? 0
             }).OrderBy(p=>p.Id).ToList();
 
             // for the view to persist current filters & "clear" button state
@@ -168,7 +169,8 @@ namespace ECommerceBatteryShop.Controllers
                     Rating = product.Rating,
                     ImageUrl = product.ImageUrl ?? string.Empty,
                     IsFavorite = favoriteIds.Contains(product.Id),
-                    Description = product.Description ?? string.Empty
+                    Description = product.Description ?? string.Empty,
+                    StockQuantity = product.Inventory?.Quantity ?? 0
                 },
                 RelatedProducts = relatedProducts
                     .Where(p => p.Id != product.Id)
@@ -180,7 +182,8 @@ namespace ECommerceBatteryShop.Controllers
                         Price = (_currency.ConvertUsdToTry(p.Price, fx) + p.ExtraAmount) * (1 + KdvRate),
                         Rating = p.Rating,
                         ImageUrl = p.ImageUrl ?? string.Empty,
-                        IsFavorite = favoriteIds.Contains(p.Id)
+                        IsFavorite = favoriteIds.Contains(p.Id),
+                        StockQuantity = p.Inventory?.Quantity ?? 0
                     }).ToList()
             };
 

--- a/ECommerceBatteryShop/Models/FavoriteViewModel.cs
+++ b/ECommerceBatteryShop/Models/FavoriteViewModel.cs
@@ -8,6 +8,8 @@
         public decimal UnitPrice { get; set; }
         public int Quantity { get; set; }
         public decimal LineTotal => UnitPrice * Quantity;
+        public int StockQuantity { get; set; }
+        public bool IsInStock => StockQuantity > 0;
     }
 
     public class FavoriteViewModel

--- a/ECommerceBatteryShop/Models/ProductViewModel.cs
+++ b/ECommerceBatteryShop/Models/ProductViewModel.cs
@@ -16,5 +16,8 @@ namespace ECommerceBatteryShop.Models
         // Add this property to fix CS1061
         public string? AttachmentUrl { get; set; }
 
+        public int StockQuantity { get; set; }
+        public bool IsInStock => StockQuantity > 0;
+
     }
 }

--- a/ECommerceBatteryShop/Services/FavoritesService.cs
+++ b/ECommerceBatteryShop/Services/FavoritesService.cs
@@ -18,7 +18,8 @@ namespace ECommerceBatteryShop.Services
         {
             IQueryable<FavoriteList> query = _db.Set<FavoriteList>()
                 .Include(f => f.Items)
-                .ThenInclude(i => i.Product);
+                .ThenInclude(i => i.Product)
+                .ThenInclude(p => p!.Inventory);
 
             FavoriteList? list = owner.UserId is int uid
                 ? await query.FirstOrDefaultAsync(f => f.UserId == uid, ct)

--- a/ECommerceBatteryShop/Views/Favorites/Index.cshtml
+++ b/ECommerceBatteryShop/Views/Favorites/Index.cshtml
@@ -85,6 +85,9 @@ else
                 var image = string.IsNullOrWhiteSpace(p.ImageUrl)
                 ? "/img/placeholder.png"
                 : (p.ImageUrl!.StartsWith("/img/") ? p.ImageUrl : "/img/" + p.ImageUrl);
+                var inStock = p.StockQuantity > 0;
+                var stockText = inStock ? "Stokta var" : "Stokta yok";
+                var stockClass = inStock ? "text-emerald-600" : "text-rose-600";
 
                 <li id="fav-@id"
                     x-data="{ removing:false }"
@@ -112,23 +115,37 @@ else
                                 <!-- Add to cart -->
                                 <form class="contents" id="cart-form-@id">
                                     @Html.AntiForgeryToken()
-                                    <button hx-post="/Cart/Add"
-                                            hx-include="#cart-form-@id"
-                                            hx-vals='{"productId": @id, "quantity": 1}'
-                                            hx-swap="none"
-                                            x-data="{ added:false }"
-                                            @@click="if(added) return; added=true; setTimeout(()=>added=false,1600)"
-                                            :class="added ? 'bg-green-500 text-white' : 'bg-amber-300 text-gray-900 hover:bg-amber-400'"
-                                            :disabled="added"
-                                            class="flex-1 h-9 rounded-md text-sm font-semibold shadow transition-colors duration-300
-                           relative overflow-hidden focus-visible:outline-none focus-visible:ring-2
-                           focus-visible:ring-yellow-400 cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed">
-                                        <span x-cloak x-show="!added">Sepete ekle</span>
-                                        <span x-cloak x-show="added" class="absolute inset-0 flex items-center justify-center gap-1">
-                                            <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5" /></svg>
-                                            <span>Sepete eklendi</span>
-                                        </span>
-                                    </button>
+                                    <div class="flex flex-1 flex-col gap-1">
+                                        @if (inStock)
+                                        {
+                                            <button hx-post="/Cart/Add"
+                                                    hx-include="#cart-form-@id"
+                                                    hx-vals='{"productId": @id, "quantity": 1}'
+                                                    hx-swap="none"
+                                                    x-data="{ added:false }"
+                                                    @@click="if(added) return; added=true; setTimeout(()=>added=false,1600)"
+                                                    :class="added ? 'bg-green-500 text-white' : 'bg-amber-300 text-gray-900 hover:bg-amber-400'"
+                                                    :disabled="added"
+                                                    class="h-9 w-full rounded-md text-sm font-semibold shadow transition-colors duration-300
+                                   relative overflow-hidden focus-visible:outline-none focus-visible:ring-2
+                                   focus-visible:ring-yellow-400 cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed">
+                                                <span x-cloak x-show="!added">Sepete ekle</span>
+                                                <span x-cloak x-show="added" class="absolute inset-0 flex items-center justify-center gap-1">
+                                                    <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5" /></svg>
+                                                    <span>Sepete eklendi</span>
+                                                </span>
+                                            </button>
+                                        }
+                                        else
+                                        {
+                                            <button type="button"
+                                                    disabled
+                                                    class="h-9 w-full rounded-md bg-gray-300 text-sm font-semibold text-gray-500 shadow cursor-not-allowed">
+                                                Stokta yok
+                                            </button>
+                                        }
+                                        <span class="text-xs font-medium @stockClass">@stockText</span>
+                                    </div>
                                 </form>
 
                                 <!-- Remove from favorites -->

--- a/ECommerceBatteryShop/Views/Home/Index.cshtml
+++ b/ECommerceBatteryShop/Views/Home/Index.cshtml
@@ -167,6 +167,11 @@
 
                 @foreach (var product in s.Products)
                 {
+                    @{ 
+                        var inStock = product.StockQuantity > 0;
+                        var stockText = inStock ? "Stokta var" : "Stokta yok";
+                        var stockClass = inStock ? "text-emerald-600" : "text-rose-600"; 
+                    }
                         <div class="flex-none min-w-0 pl-2 lg:basis-[calc((100%-3*var(--g))/4)] md:basis-[calc((100%-2*var(--g))/3)] basis-[calc((100%-1*var(--g))/2)] snap-start">
                             <article class="group h-72 flex flex-col rounded-xl border border-slate-200 bg-white shadow-sm transition hover:shadow-md">
                                 <!-- Image -->
@@ -214,39 +219,53 @@
 
                                     <!-- Actions -->
                                     <div class="mt-3 mb-3 flex items-center gap-2">
-                                        <button
-                                            hx-post="/Cart/Add"
-                                            hx-vals='{"productId": @product.Id, "quantity": 1}'
-                                            hx-swap="none"
-                                            x-data="{ added: false }"
-                                            @@click="if (added) return; added = true; setTimeout(() => added = false, 1600);"
-                                            :class="added ? 'bg-green-500 text-white' : 'bg-amber-300 text-gray-900 hover:bg-amber-400'"
-                                            class="flex-1 h-9 rounded-md text-sm font-semibold shadow transition-colors duration-300 relative overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 cursor-pointer">
-                                            <span x-show="!added"
-                                                  x-transition:enter="transition transform ease-out duration-250"
-                                                  x-transition:enter-start="-translate-y-3 opacity-0"
-                                                  x-transition:enter-end="translate-y-0 opacity-100"
-                                                  x-transition:leave="transition transform ease-in duration-200"
-                                                  x-transition:leave-start="translate-y-0 opacity-100"
-                                                  x-transition:leave-end="translate-y-3 opacity-0"
-                                                  class="block">
-                                                Sepete ekle
-                                            </span>
+                                        <div class="flex flex-1 flex-col gap-1">
+                                            @if (inStock)
+                                            {
+                                                <button
+                                                    hx-post="/Cart/Add"
+                                                    hx-vals='{"productId": @product.Id, "quantity": 1}'
+                                                    hx-swap="none"
+                                                    x-data="{ added: false }"
+                                                    @@click="if (added) return; added = true; setTimeout(() => added = false, 1600);"
+                                                    :class="added ? 'bg-green-500 text-white' : 'bg-amber-300 text-gray-900 hover:bg-amber-400'"
+                                                    class="h-9 w-full rounded-md text-sm font-semibold shadow transition-colors duration-300 relative overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 cursor-pointer">
+                                                    <span x-show="!added"
+                                                          x-transition:enter="transition transform ease-out duration-250"
+                                                          x-transition:enter-start="-translate-y-3 opacity-0"
+                                                          x-transition:enter-end="translate-y-0 opacity-100"
+                                                          x-transition:leave="transition transform ease-in duration-200"
+                                                          x-transition:leave-start="translate-y-0 opacity-100"
+                                                          x-transition:leave-end="translate-y-3 opacity-0"
+                                                          class="block">
+                                                        Sepete ekle
+                                                    </span>
 
-                                            <span x-show="added"
-                                                  x-transition:enter="transition transform ease-out duration-250"
-                                                  x-transition:enter-start="translate-y-3 opacity-0"
-                                                  x-transition:enter-end="translate-y-0 opacity-100"
-                                                  x-transition:leave="transition transform ease-in duration-200"
-                                                  x-transition:leave-start="translate-y-0 opacity-100"
-                                                  x-transition:leave-end="-translate-y-3 opacity-0"
-                                                  class="absolute inset-0 flex items-center justify-center gap-1">
-                                                <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 align-middle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                    <path d="M20 6L9 17l-5-5"/>
-                                                </svg>
-                                                <span class="align-middle text-white">Sepete eklendi</span>
-                                            </span>
-                                        </button>
+                                                    <span x-show="added"
+                                                          x-transition:enter="transition transform ease-out duration-250"
+                                                          x-transition:enter-start="translate-y-3 opacity-0"
+                                                          x-transition:enter-end="translate-y-0 opacity-100"
+                                                          x-transition:leave="transition transform ease-in duration-200"
+                                                          x-transition:leave-start="translate-y-0 opacity-100"
+                                                          x-transition:leave-end="-translate-y-3 opacity-0"
+                                                          class="absolute inset-0 flex items-center justify-center gap-1">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 align-middle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                            <path d="M20 6L9 17l-5-5"/>
+                                                        </svg>
+                                                        <span class="align-middle text-white">Sepete eklendi</span>
+                                                    </span>
+                                                </button>
+                                            }
+                                            else
+                                            {
+                                                <button type="button"
+                                                        disabled
+                                                        class="h-9 w-full rounded-md bg-gray-300 text-sm font-semibold text-gray-500 shadow cursor-not-allowed">
+                                                    Stokta yok
+                                                </button>
+                                            }
+                                            <span class="text-xs font-medium @stockClass">@stockText</span>
+                                        </div>
 
                                    <!-- Favorite (Heart) -->
         <button

--- a/ECommerceBatteryShop/Views/Product/Details.cshtml
+++ b/ECommerceBatteryShop/Views/Product/Details.cshtml
@@ -1,7 +1,9 @@
 ﻿@using System.Globalization
 @model ECommerceBatteryShop.Models.ProductDetailsViewModel
 @{
-    
+    var productInStock = Model.product.StockQuantity > 0;
+    var productStockText = productInStock ? "Stokta var" : "Stokta yok";
+    var productStockClass = productInStock ? "text-emerald-600" : "text-rose-600";
 }
 
 <main class="bg-white min-h-screen pt-28 pb-24">
@@ -47,6 +49,8 @@
                     @Model.product.Price.ToString("C", new System.Globalization.CultureInfo("tr-TR"))
                 </div>
 
+                <p class="mt-2 text-sm font-medium @productStockClass">@productStockText</p>
+
                 <!-- Qty + Actions -->
                 <div class="mt-6 flex flex-wrap items-center gap-3">
                     <!-- Qty input -->
@@ -74,43 +78,54 @@
                     </div>
 
                     <!-- CTA buttons -->
-                    <button hx-post="/Cart/Add"
-                            :hx-vals="JSON.stringify({ productId: @Model.product.Id, quantity: qty })"
-                            hx-swap="none"
-                            x-data="{ added: false }"
-                            @@click="if (added) return; added = true; setTimeout(() => added = false, 1600);"
-                            :class="added
-                                    ? 'bg-green-500 text-white'
-                                    : 'bg-amber-300 text-gray-900 hover:bg-amber-400'"
-                            class="h-11 min-w-[8rem] rounded-md text-sm font-semibold shadow
-           transition-colors duration-300 relative overflow-hidden
-           rounded-md
-           focus-visible:ring-yellow-400 cursor-pointer ">
-                        <span x-show="!added"
-                              x-transition:enter="transition transform ease-out duration-250"
-                              x-transition:enter-start="-translate-y-3 opacity-0"
-                              x-transition:enter-end="translate-y-0 opacity-100"
-                              x-transition:leave="transition transform ease-in duration-200"
-                              x-transition:leave-start="translate-y-0 opacity-100"
-                              x-transition:leave-end="translate-y-3 opacity-0"
-                              class="block">
-                            Sepete ekle
-                        </span>
+                    <div class="flex flex-col gap-1">
+                        @if (productInStock)
+                        {
+                            <button hx-post="/Cart/Add"
+                                    :hx-vals="JSON.stringify({ productId: @Model.product.Id, quantity: qty })"
+                                    hx-swap="none"
+                                    x-data="{ added: false }"
+                                    @@click="if (added) return; added = true; setTimeout(() => added = false, 1600);"
+                                    :class="added
+                                            ? 'bg-green-500 text-white'
+                                            : 'bg-amber-300 text-gray-900 hover:bg-amber-400'"
+                                    class="h-11 min-w-[8rem] rounded-md text-sm font-semibold shadow transition-colors duration-300 relative overflow-hidden rounded-md focus-visible:ring-yellow-400 cursor-pointer ">
+                                <span x-show="!added"
+                                      x-transition:enter="transition transform ease-out duration-250"
+                                      x-transition:enter-start="-translate-y-3 opacity-0"
+                                      x-transition:enter-end="translate-y-0 opacity-100"
+                                      x-transition:leave="transition transform ease-in duration-200"
+                                      x-transition:leave-start="translate-y-0 opacity-100"
+                                      x-transition:leave-end="translate-y-3 opacity-0"
+                                      class="block">
+                                    Sepete ekle
+                                </span>
 
-                        <span x-show="added"
-                              x-transition:enter="transition transform ease-out duration-250"
-                              x-transition:enter-start="translate-y-3 opacity-0"
-                              x-transition:enter-end="translate-y-0 opacity-100"
-                              x-transition:leave="transition transform ease-in duration-200"
-                              x-transition:leave-start="translate-y-0 opacity-100"
-                              x-transition:leave-end="-translate-y-3 opacity-0"
-                              class="absolute inset-0 flex items-center justify-center gap-1">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 align-middle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path d="M20 6L9 17l-5-5" />
-                            </svg>
-                            <span class="align-middle">Sepete eklendi</span>
-                        </span>
-                    </button>
+                                <span x-show="added"
+                                      x-transition:enter="transition transform ease-out duration-250"
+                                      x-transition:enter-start="translate-y-3 opacity-0"
+                                      x-transition:enter-end="translate-y-0 opacity-100"
+                                      x-transition:leave="transition transform ease-in duration-200"
+                                      x-transition:leave-start="translate-y-0 opacity-100"
+                                      x-transition:leave-end="-translate-y-3 opacity-0"
+                                      class="absolute inset-0 flex items-center justify-center gap-1">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 align-middle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                        <path d="M20 6L9 17l-5-5" />
+                                    </svg>
+                                    <span class="align-middle">Sepete eklendi</span>
+                                </span>
+                            </button>
+                        }
+                        else
+                        {
+                            <button type="button"
+                                    disabled
+                                    class="h-11 min-w-[8rem] rounded-md bg-gray-300 text-sm font-semibold text-gray-500 shadow cursor-not-allowed">
+                                Stokta yok
+                            </button>
+                        }
+                        <span class="text-xs font-medium @productStockClass">@productStockText</span>
+                    </div>
 
                     <button type="button"
                             x-data="{ fav: @(Model.product.IsFavorite ? "true" : "false"), busy: false }"
@@ -308,6 +323,11 @@
 
                 @foreach (var product in Model.RelatedProducts)
                 {
+                    @{ 
+                        var inStock = product.StockQuantity > 0;
+                        var stockText = inStock ? "Stokta var" : "Stokta yok";
+                        var stockClass = inStock ? "text-emerald-600" : "text-rose-600"; 
+                    }
                             <div class="flex-none min-w-0 pl-2 lg:basis-[calc((100%-3*var(--g))/4)] md:basis-[calc((100%-2*var(--g))/3)] basis-[calc((100%-1*var(--g))/2)] snap-start">
                                 <article class="group h-72 flex flex-col rounded-xl border border-slate-200 bg-white shadow-sm transition hover:shadow-md">
                                     <!-- Image -->
@@ -355,39 +375,53 @@
 
                                         <!-- Actions -->
                                         <div class="mt-3 mb-3 flex items-center gap-2">
-                                            <button
-                                                hx-post="/Cart/Add"
-                                                hx-vals='{"productId": @product.Id, "quantity": 1}'
-                                                hx-swap="none"
-                                                x-data="{ added: false }"
-                                                @@click="if (added) return; added = true; setTimeout(() => added = false, 1600);"
-                                                :class="added ? 'bg-green-500 text-white' : 'bg-amber-300 text-gray-900 hover:bg-amber-400'"
-                                                class="flex-1 h-9 rounded-md text-sm font-semibold shadow transition-colors duration-300 relative overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 cursor-pointer">
-                                                <span x-show="!added"
-                                                      x-transition:enter="transition transform ease-out duration-250"
-                                                      x-transition:enter-start="-translate-y-3 opacity-0"
-                                                      x-transition:enter-end="translate-y-0 opacity-100"
-                                                      x-transition:leave="transition transform ease-in duration-200"
-                                                      x-transition:leave-start="translate-y-0 opacity-100"
-                                                      x-transition:leave-end="translate-y-3 opacity-0"
-                                                      class="block">
-                                                    Sepete ekle
-                                                </span>
+                                            <div class="flex flex-1 flex-col gap-1">
+                                                @if (inStock)
+                                                {
+                                                    <button
+                                                        hx-post="/Cart/Add"
+                                                        hx-vals='{"productId": @product.Id, "quantity": 1}'
+                                                        hx-swap="none"
+                                                        x-data="{ added: false }"
+                                                        @@click="if (added) return; added = true; setTimeout(() => added = false, 1600);"
+                                                        :class="added ? 'bg-green-500 text-white' : 'bg-amber-300 text-gray-900 hover:bg-amber-400'"
+                                                        class="h-9 w-full rounded-md text-sm font-semibold shadow transition-colors duration-300 relative overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 cursor-pointer">
+                                                        <span x-show="!added"
+                                                              x-transition:enter="transition transform ease-out duration-250"
+                                                              x-transition:enter-start="-translate-y-3 opacity-0"
+                                                              x-transition:enter-end="translate-y-0 opacity-100"
+                                                              x-transition:leave="transition transform ease-in duration-200"
+                                                              x-transition:leave-start="translate-y-0 opacity-100"
+                                                              x-transition:leave-end="translate-y-3 opacity-0"
+                                                              class="block">
+                                                            Sepete ekle
+                                                        </span>
 
-                                                <span x-show="added"
-                                                      x-transition:enter="transition transform ease-out duration-250"
-                                                      x-transition:enter-start="translate-y-3 opacity-0"
-                                                      x-transition:enter-end="translate-y-0 opacity-100"
-                                                      x-transition:leave="transition transform ease-in duration-200"
-                                                      x-transition:leave-start="translate-y-0 opacity-100"
-                                                      x-transition:leave-end="-translate-y-3 opacity-0"
-                                                      class="absolute inset-0 flex items-center justify-center gap-1">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 align-middle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                                        <path d="M20 6L9 17l-5-5"/>
-                                                    </svg>
-                                                    <span class="align-middle text-white">Sepete eklendi</span>
-                                                </span>
-                                            </button>
+                                                        <span x-show="added"
+                                                              x-transition:enter="transition transform ease-out duration-250"
+                                                              x-transition:enter-start="translate-y-3 opacity-0"
+                                                              x-transition:enter-end="translate-y-0 opacity-100"
+                                                              x-transition:leave="transition transform ease-in duration-200"
+                                                              x-transition:leave-start="translate-y-0 opacity-100"
+                                                              x-transition:leave-end="-translate-y-3 opacity-0"
+                                                              class="absolute inset-0 flex items-center justify-center gap-1">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 align-middle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                                                <path d="M20 6L9 17l-5-5"/>
+                                                            </svg>
+                                                            <span class="align-middle text-white">Sepete eklendi</span>
+                                                        </span>
+                                                    </button>
+                                                }
+                                                else
+                                                {
+                                                    <button type="button"
+                                                            disabled
+                                                            class="h-9 w-full rounded-md bg-gray-300 text-sm font-semibold text-gray-500 shadow cursor-not-allowed">
+                                                        Stokta yok
+                                                    </button>
+                                                }
+                                                <span class="text-xs font-medium @stockClass">@stockText</span>
+                                            </div>
 
                                        <!-- Favorite (Heart) -->
             <button

--- a/ECommerceBatteryShop/Views/Product/Index.cshtml
+++ b/ECommerceBatteryShop/Views/Product/Index.cshtml
@@ -145,6 +145,9 @@ else
     <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-6">
         @foreach (var product in products)
         {
+            var inStock = product.StockQuantity > 0;
+            var stockText = inStock ? "Stokta var" : "Stokta yok";
+            var stockClass = inStock ? "text-emerald-600" : "text-rose-600";
             var href = Url.Action("Details", "Product", new { id = product.Id });
             var price = product.Price.ToString("C", new CultureInfo("tr-TR"));
             var fullStars = (int)Math.Floor(product.Rating);
@@ -181,38 +184,52 @@ else
                 </a>
 
                 <div class="mt-3 mb-3 flex items-center gap-2 px-3">
-                    <button hx-post="/Cart/Add"
-                            hx-vals='{"productId": @product.Id, "quantity": 1}'
-                            hx-swap="none"
-                            x-data="{ added: false }"
-                            @@click="if (added) return; added = true; setTimeout(() => added = false, 1600);"
-                            :class="added ? 'bg-green-500 text-white' : 'bg-amber-300 text-gray-900 hover:bg-amber-400'"
-                            class="flex-1 h-9 rounded-md text-sm font-semibold shadow transition-colors duration-300 relative overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 cursor-pointer">
-                        <span x-show="!added"
-                              x-transition:enter="transition transform ease-out duration-250"
-                              x-transition:enter-start="-translate-y-3 opacity-0"
-                              x-transition:enter-end="translate-y-0 opacity-100"
-                              x-transition:leave="transition transform ease-in duration-200"
-                              x-transition:leave-start="translate-y-0 opacity-100"
-                              x-transition:leave-end="translate-y-3 opacity-0"
-                              class="block">
-                            Sepete ekle
-                        </span>
+                    <div class="flex flex-1 flex-col gap-1">
+                        @if (inStock)
+                        {
+                            <button hx-post="/Cart/Add"
+                                    hx-vals='{"productId": @product.Id, "quantity": 1}'
+                                    hx-swap="none"
+                                    x-data="{ added: false }"
+                                    @@click="if (added) return; added = true; setTimeout(() => added = false, 1600);"
+                                    :class="added ? 'bg-green-500 text-white' : 'bg-amber-300 text-gray-900 hover:bg-amber-400'"
+                                    class="h-9 w-full rounded-md text-sm font-semibold shadow transition-colors duration-300 relative overflow-hidden focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-yellow-400 cursor-pointer">
+                                <span x-show="!added"
+                                      x-transition:enter="transition transform ease-out duration-250"
+                                      x-transition:enter-start="-translate-y-3 opacity-0"
+                                      x-transition:enter-end="translate-y-0 opacity-100"
+                                      x-transition:leave="transition transform ease-in duration-200"
+                                      x-transition:leave-start="translate-y-0 opacity-100"
+                                      x-transition:leave-end="translate-y-3 opacity-0"
+                                      class="block">
+                                    Sepete ekle
+                                </span>
 
-                        <span x-show="added"
-                              x-transition:enter="transition transform ease-out duration-250"
-                              x-transition:enter-start="translate-y-3 opacity-0"
-                              x-transition:enter-end="translate-y-0 opacity-100"
-                              x-transition:leave="transition transform ease-in duration-200"
-                              x-transition:leave-start="translate-y-0 opacity-100"
-                              x-transition:leave-end="-translate-y-3 opacity-0"
-                              class="absolute inset-0 flex items-center justify-center gap-1">
-                            <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 align-middle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                                <path d="M20 6L9 17l-5-5" />
-                            </svg>
-                            <span class="align-middle text-white">Sepete eklendi</span>
-                        </span>
-                    </button>
+                                <span x-show="added"
+                                      x-transition:enter="transition transform ease-out duration-250"
+                                      x-transition:enter-start="translate-y-3 opacity-0"
+                                      x-transition:enter-end="translate-y-0 opacity-100"
+                                      x-transition:leave="transition transform ease-in duration-200"
+                                      x-transition:leave-start="translate-y-0 opacity-100"
+                                      x-transition:leave-end="-translate-y-3 opacity-0"
+                                      class="absolute inset-0 flex items-center justify-center gap-1">
+                                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 align-middle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                                        <path d="M20 6L9 17l-5-5" />
+                                    </svg>
+                                    <span class="align-middle text-white">Sepete eklendi</span>
+                                </span>
+                            </button>
+                        }
+                        else
+                        {
+                            <button type="button"
+                                    disabled
+                                    class="h-9 w-full rounded-md bg-gray-300 text-sm font-semibold text-gray-500 shadow cursor-not-allowed">
+                                Stokta yok
+                            </button>
+                        }
+                        <span class="text-xs font-medium @stockClass">@stockText</span>
+                    </div>
 
                     <button type="button"
                             x-data="{ fav: @(product.IsFavorite ? "true" : "false"), busy: false }"


### PR DESCRIPTION
## Summary
- surface stock availability information through product and favorite view models
- eager load inventory data in repositories and services that feed product listings
- update add-to-cart UI across product, home, and favorites pages to show "Stokta var" or "Stokta yok" and disable actions when out of stock

## Testing
- dotnet build *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1106f8d70832098efbfe620083974